### PR TITLE
feat: add suspense boundary on filter

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -95,6 +95,7 @@ export { generateMetadata };
 // 2- configure CI releases
 // 2- add slider for mobile calendars
 // 2- change spinner for skeleton
+// 2- improve SEO (a11y) + performance
 // 2- refine styles (hover blocks, dark mode, modals, calendar, days etc).
 // 35- Check copies (what is premium, limitations, behind flag features, etc)
 // 34- Ko-Fi BE integration (webhook not working on localhost)

--- a/src/application/actions/updateFilter.ts
+++ b/src/application/actions/updateFilter.ts
@@ -1,0 +1,26 @@
+"use server";
+
+import type { SearchParams } from "@const/types";
+import { redirect } from "next/navigation";
+
+export type FilterType = keyof SearchParams;
+
+export async function updateSingleFilterAction(
+	type: FilterType,
+	value: string,
+	currentPath: string,
+	currentSearchParams: string,
+) {
+	const params = new URLSearchParams(currentSearchParams);
+
+	if (value && value !== "false" && value !== "0") {
+		params.set(type, value);
+	} else {
+		params.delete(type);
+	}
+
+	params.delete("page");
+
+	const queryString = params.toString();
+	redirect(`${currentPath}${queryString ? `?${queryString}` : ""}`);
+}

--- a/src/ui/hooks/useFilterAction/useFilterAction.ts
+++ b/src/ui/hooks/useFilterAction/useFilterAction.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { type FilterType, updateSingleFilterAction } from "@application/actions/updateFilter";
+import { usePathname, useSearchParams } from "next/navigation";
+import { useTransition } from "react";
+
+export function useFilterAction() {
+	const pathname = usePathname();
+	const searchParams = useSearchParams();
+	const [isPending, startTransition] = useTransition();
+
+	const updateFilter = (type: FilterType, value: string) => {
+		startTransition(async () => {
+			await updateSingleFilterAction(type, value, pathname, searchParams.toString());
+		});
+	};
+
+	return {
+		updateFilter,
+		isPending,
+	};
+}

--- a/src/ui/modules/components/appSidebar/components/appSidebar/atoms/filtersPanel/atoms/allowPastDays/AllowPastDays.tsx
+++ b/src/ui/modules/components/appSidebar/components/appSidebar/atoms/filtersPanel/atoms/allowPastDays/AllowPastDays.tsx
@@ -1,38 +1,28 @@
 "use client";
 
 import type { SearchParams } from "@const/types";
-import { createQueryString } from "@modules/components/appSidebar/components/appSidebar/utils/createQueryString/createQueryString";
 import { Label } from "@modules/components/core/label/Label";
 import { Switch } from "@modules/components/core/switch/Switch";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useFilterAction } from "@ui/hooks/useFilterAction/useFilterAction";
 import { useTranslations } from "next-intl";
-import { startTransition, useCallback, useId, useMemo, useState } from "react";
+import { useCallback, useId, useMemo } from "react";
 
 export interface AllowPastDaysProps {
 	allowPastDays: SearchParams["allowPastDays"];
 }
 
 export const AllowPastDays = ({ allowPastDays }: AllowPastDaysProps) => {
-	const router = useRouter();
-	const pathname = usePathname();
-	const searchParams = useSearchParams();
 	const id = useId();
-	const [isEnabled, setIsEnabled] = useState(allowPastDays === "true");
+	const { updateFilter, isPending } = useFilterAction();
 	const t = useTranslations("filters.allowPastDays");
+
+	const isEnabled = allowPastDays === "true";
 
 	const handleSwitchChange = useCallback(
 		(checked: boolean) => {
-			setIsEnabled(checked);
-
-			const query = createQueryString({
-				type: "allowPastDays",
-				value: String(checked),
-				searchParams,
-			});
-
-			startTransition(() => router.push(`${pathname}?${query}`, { scroll: false }));
+			updateFilter("allowPastDays", String(checked));
 		},
-		[pathname, router, searchParams],
+		[updateFilter],
 	);
 
 	const labelText = useMemo(() => (isEnabled ? t("enabled") : t("disabled")), [isEnabled, t]);
@@ -40,14 +30,14 @@ export const AllowPastDays = ({ allowPastDays }: AllowPastDaysProps) => {
 	const switchControl = useMemo(
 		() => (
 			<div className="flex items-center gap-2">
-				<Switch id={id} checked={isEnabled} onCheckedChange={handleSwitchChange} />
+				<Switch id={id} checked={isEnabled} onCheckedChange={handleSwitchChange} disabled={isPending} />
 				<Label htmlFor={id} className="text-sm cursor-pointer select-none">
 					{labelText}
 				</Label>
 			</div>
 		),
-		[isEnabled, handleSwitchChange, labelText, id],
+		[isEnabled, handleSwitchChange, labelText, id, isPending],
 	);
 
-	return <div className="flex items-center justify-between">{switchControl}</div>;
+	return <div className={`flex items-center justify-between ${isPending ? "opacity-50" : ""}`}>{switchControl}</div>;
 };

--- a/src/ui/modules/components/appSidebar/components/appSidebar/atoms/filtersPanel/atoms/carryOverMonths/CarryOverMonths.tsx
+++ b/src/ui/modules/components/appSidebar/components/appSidebar/atoms/filtersPanel/atoms/carryOverMonths/CarryOverMonths.tsx
@@ -2,14 +2,13 @@
 
 import { usePremiumStore } from "@application/stores/premium/premiumStore";
 import type { SearchParams } from "@const/types";
-import { createQueryString } from "@modules/components/appSidebar/components/appSidebar/utils/createQueryString/createQueryString";
+import { useFilterAction } from "@ui/hooks/useFilterAction/useFilterAction";
 import { FILTER_MAXIMUM_VALUES } from "@ui/modules/components/appSidebar/const";
 import { Label } from "@ui/modules/components/core/label/Label";
 import { Slider } from "@ui/modules/components/core/slider/Slider";
 import { PremiumLock } from "@ui/modules/components/premium/components/premiumLock/PremiumLock";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { startTransition, useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef } from "react";
 
 export interface CarryOverMonthsProps {
 	carryOverMonths: SearchParams["carryOverMonths"];
@@ -17,11 +16,12 @@ export interface CarryOverMonthsProps {
 
 export const CarryOverMonths = ({ carryOverMonths }: CarryOverMonthsProps) => {
 	const t = useTranslations("filters.carryOverMonths");
-	const router = useRouter();
-	const pathname = usePathname();
-	const searchParams = useSearchParams();
+	const { updateFilter, isPending } = useFilterAction();
 	const { isPremiumUser } = usePremiumStore();
-	const [value, setValue] = useState([Number(carryOverMonths)]);
+	const debounceRef = useRef<NodeJS.Timeout>(null);
+
+	const currentValue = Number(carryOverMonths) || 1;
+	const value = useMemo(() => [currentValue], [currentValue]);
 
 	const maxValue = useMemo(
 		() =>
@@ -35,30 +35,31 @@ export const CarryOverMonths = ({ carryOverMonths }: CarryOverMonthsProps) => {
 				return;
 			}
 
-			setValue(newValue);
+			if (debounceRef.current) {
+				clearTimeout(debounceRef.current);
+			}
 
-			const query = createQueryString({
-				type: "carryOverMonths",
-				value: String(newValue[0]),
-				searchParams,
-			});
-
-			startTransition(() => router.push(`${pathname}?${query}`, { scroll: false }));
+			debounceRef.current = setTimeout(() => {
+				updateFilter("carryOverMonths", String(newValue[0]));
+			}, 100);
 		},
-		[isPremiumUser, router, pathname, searchParams],
+		[isPremiumUser, updateFilter],
 	);
 
-	const sliderDisabled = useMemo(() => !isPremiumUser && value[0] > 1, [isPremiumUser, value]);
+	const sliderDisabled = useMemo(
+		() => isPending || (!isPremiumUser && currentValue > 1),
+		[isPending, isPremiumUser, currentValue],
+	);
 
 	const label = useMemo(
 		() => (
 			<div className="flex items-center justify-between">
 				<Label htmlFor="months-slider" className="text-sm select-none">
-					{t("monthsToShow", { months: value[0] })}
+					{t("monthsToShow", { months: currentValue })}
 				</Label>
 			</div>
 		),
-		[value, t],
+		[currentValue, t],
 	);
 
 	const sliderRangeLabels = useMemo(
@@ -73,7 +74,7 @@ export const CarryOverMonths = ({ carryOverMonths }: CarryOverMonthsProps) => {
 
 	const sliderComponent = useMemo(
 		() => (
-			<div className="space-y-4">
+			<div className={`space-y-4 ${isPending ? "opacity-50" : ""}`}>
 				{label}
 				<Slider
 					min={1}
@@ -84,11 +85,10 @@ export const CarryOverMonths = ({ carryOverMonths }: CarryOverMonthsProps) => {
 					disabled={sliderDisabled}
 					className="w-full"
 				/>
-
 				{sliderRangeLabels}
 			</div>
 		),
-		[label, maxValue, value, handleValueChange, sliderDisabled, sliderRangeLabels],
+		[label, maxValue, value, handleValueChange, sliderDisabled, sliderRangeLabels, isPending],
 	);
 
 	if (!isPremiumUser) {

--- a/src/ui/modules/components/appSidebar/components/appSidebar/atoms/filtersPanel/atoms/countries/Countries.tsx
+++ b/src/ui/modules/components/appSidebar/components/appSidebar/atoms/filtersPanel/atoms/countries/Countries.tsx
@@ -1,32 +1,16 @@
 import type { SearchParams } from "@const/types";
 import { getCountries } from "@infrastructure/services/country/getCountries/getCountries";
-import { Combobox } from "@ui/modules/components/core/combobox/Combobox";
-import type { Locale } from "next-intl";
-import { getTranslations } from "next-intl/server";
-import { cache, memo } from "react";
-
-export interface CountriesProps {
-	country: SearchParams["country"];
-	locale: Locale;
-}
+import { cache } from "react";
+import { CountriesClient } from "./atoms/CountriesClient";
 
 const getCachedCountries = cache(getCountries);
 
-export const Countries = memo(async ({ country, locale }: CountriesProps) => {
-	const t = await getTranslations({ locale, namespace: "filters.countries" });
+export interface CountriesProps {
+	country: SearchParams["country"];
+}
+
+export const Countries = async ({ country }: CountriesProps) => {
 	const countries = await getCachedCountries();
 
-	return (
-		<Combobox
-			value={country}
-			options={countries}
-			type="country"
-			className="w-full"
-			label={t("label")}
-			heading={t("heading")}
-			placeholder={t("placeholder")}
-			searchPlaceholder={t("searchPlaceholder")}
-			notFoundText={t("notFound")}
-		/>
-	);
-});
+	return <CountriesClient countries={countries} selectedCountry={country} />;
+};

--- a/src/ui/modules/components/appSidebar/components/appSidebar/atoms/filtersPanel/atoms/countries/atoms/CountriesClient.tsx
+++ b/src/ui/modules/components/appSidebar/components/appSidebar/atoms/filtersPanel/atoms/countries/atoms/CountriesClient.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import type { CountryDTO } from "@application/dto/country/types";
+import { Combobox } from "@modules/components/core/combobox/Combobox";
+import { useFilterAction } from "@ui/hooks/useFilterAction/useFilterAction";
+import { useTranslations } from "next-intl";
+
+interface CountriesClientProps {
+	countries: CountryDTO[];
+	selectedCountry?: string;
+}
+
+export const CountriesClient = ({ countries, selectedCountry }: CountriesClientProps) => {
+	const t = useTranslations("filters.countries");
+	const { isPending } = useFilterAction();
+
+	return (
+		<div className={isPending ? "opacity-50" : ""}>
+			<Combobox
+				type="country"
+				options={countries}
+				value={selectedCountry}
+				label={t("label")}
+				heading={t("heading")}
+				placeholder={t("placeholder")}
+				searchPlaceholder={t("searchPlaceholder")}
+				notFoundText={t("notFound")}
+				disabled={isPending}
+			/>
+		</div>
+	);
+};

--- a/src/ui/modules/components/appSidebar/components/appSidebar/atoms/filtersPanel/atoms/regions/Regions.tsx
+++ b/src/ui/modules/components/appSidebar/components/appSidebar/atoms/filtersPanel/atoms/regions/Regions.tsx
@@ -1,10 +1,8 @@
 import type { SearchParams } from "@const/types";
 import { getCountries } from "@infrastructure/services/country/getCountries/getCountries";
 import { getRegions } from "@infrastructure/services/region/getRegions/getRegions";
-import { Combobox } from "@ui/modules/components/core/combobox/Combobox";
-import type { Locale } from "next-intl";
-import { getTranslations } from "next-intl/server";
 import { cache } from "react";
+import { RegionsClient } from "./atoms/RegionsClient";
 
 const getCachedCountries = cache(getCountries);
 const getCachedRegions = cache(getRegions);
@@ -12,34 +10,12 @@ const getCachedRegions = cache(getRegions);
 export interface RegionsProps {
 	country: SearchParams["country"];
 	region: SearchParams["region"];
-	locale: Locale;
 }
 
-export const Regions = async ({ country, region, locale }: RegionsProps) => {
-	const t = await getTranslations({ locale, namespace: "filters.regions" });
+export const Regions = async ({ country, region }: RegionsProps) => {
 	const countries = await getCachedCountries();
 	const userCountry = countries.find(({ value }) => value.toLowerCase() === country);
 	const regions = await getCachedRegions(userCountry?.value);
-	const isDisabled = !userCountry || !regions?.length;
 
-	return (
-		<Combobox
-			value={region}
-			options={regions}
-			type="region"
-			disabled={isDisabled}
-			className="w-full"
-			label={t("label")}
-			heading={t("heading", {
-				hasCountry: userCountry?.label ? 1 : 0,
-				country: userCountry?.label ?? "",
-			})}
-			placeholder={t("placeholder", {
-				count: regions.length,
-				country: userCountry?.label ?? "",
-			})}
-			searchPlaceholder={t("searchPlaceholder")}
-			notFoundText={t("notFound")}
-		/>
-	);
+	return <RegionsClient regions={regions} selectedRegion={region} userCountry={userCountry} />;
 };

--- a/src/ui/modules/components/appSidebar/components/appSidebar/atoms/filtersPanel/atoms/regions/atoms/RegionsClient.tsx
+++ b/src/ui/modules/components/appSidebar/components/appSidebar/atoms/filtersPanel/atoms/regions/atoms/RegionsClient.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import type { CountryDTO } from "@application/dto/country/types";
+import type { RegionDTO } from "@application/dto/region/types";
+import { Combobox } from "@modules/components/core/combobox/Combobox";
+import { useFilterAction } from "@ui/hooks/useFilterAction/useFilterAction";
+import { useTranslations } from "next-intl";
+
+interface RegionsClientProps {
+	regions: RegionDTO[];
+	selectedRegion?: string;
+	userCountry?: CountryDTO;
+}
+
+export const RegionsClient = ({ regions, selectedRegion, userCountry }: RegionsClientProps) => {
+	const t = useTranslations("filters.regions");
+	const { isPending } = useFilterAction();
+	const isDisabled = isPending || !userCountry || !regions?.length;
+	return (
+		<div className={isPending ? "opacity-50" : ""}>
+			<Combobox
+				type="region"
+				value={selectedRegion}
+				options={regions}
+				disabled={isDisabled}
+				className="w-full"
+				label={t("label")}
+				heading={t("heading", {
+					hasCountry: userCountry?.label ? 1 : 0,
+					country: userCountry?.label ?? "",
+				})}
+				placeholder={t("placeholder", {
+					count: regions.length,
+					country: userCountry?.label ?? "",
+				})}
+				searchPlaceholder={t("searchPlaceholder")}
+				notFoundText={t("notFound")}
+			/>
+		</div>
+	);
+};

--- a/src/ui/modules/components/appSidebar/components/appSidebar/atoms/filtersPanel/atoms/settingsItem/hooks/useSidebarItems/useSidebarItems.tsx
+++ b/src/ui/modules/components/appSidebar/components/appSidebar/atoms/filtersPanel/atoms/settingsItem/hooks/useSidebarItems/useSidebarItems.tsx
@@ -8,17 +8,27 @@ import { PtoDays } from "@modules/components/appSidebar/components/appSidebar/at
 import { Regions } from "@modules/components/appSidebar/components/appSidebar/atoms/filtersPanel/atoms/regions/Regions";
 import { Years } from "@modules/components/appSidebar/components/appSidebar/atoms/filtersPanel/atoms/years/Years";
 import type { SidebarItem } from "@modules/components/appSidebar/components/appSidebar/atoms/filtersPanel/types";
+import { mergeClasses } from "@ui/utils/mergeClasses/mergeClasses";
 import { Calendar, CalendarDays, MapPin, MapPinned, SlidersHorizontal, ToggleLeftIcon } from "lucide-react";
 import { type Locale, useTranslations } from "next-intl";
-import { useMemo } from "react";
+import { Suspense, useMemo } from "react";
 
 interface UseSidebarItemsParams extends SearchParams {
 	locale: Locale;
 }
 
+const FilterSkeleton = ({ className }: { className?: string }) => {
+	return <div className={mergeClasses("bg-slate-200 animate-pulse rounded-md", className)} />;
+};
+
 export function useSidebarItems(params: UseSidebarItemsParams): SidebarItem[] {
 	const { country, region, ptoDays, year, allowPastDays, carryOverMonths, locale } = params;
 	const t = useTranslations("filters");
+
+	const suspenseKey = useMemo(
+		() => JSON.stringify({ country, region, ptoDays, year, allowPastDays, carryOverMonths }),
+		[country, region, ptoDays, year, allowPastDays, carryOverMonths],
+	);
 
 	return useMemo(
 		() => [
@@ -26,41 +36,65 @@ export function useSidebarItems(params: UseSidebarItemsParams): SidebarItem[] {
 				id: "pto-days",
 				title: t("days"),
 				icon: CalendarDays,
-				renderComponent: () => <PtoDays ptoDays={ptoDays} />,
+				renderComponent: () => (
+					<Suspense key={`pto-days-${suspenseKey}`} fallback={<FilterSkeleton />}>
+						<PtoDays ptoDays={ptoDays} />
+					</Suspense>
+				),
 			},
 			{
 				id: "country",
 				title: t("country"),
 				icon: MapPin,
-				renderComponent: () => <Countries country={country} locale={locale} />,
+				renderComponent: () => (
+					<Suspense key={`country-${suspenseKey}`} fallback={<FilterSkeleton />}>
+						<Countries country={country} />
+					</Suspense>
+				),
 			},
 			{
 				id: "region",
 				title: t("region"),
 				icon: MapPinned,
-				renderComponent: () => <Regions country={country} region={region} locale={locale} />,
+				renderComponent: () => (
+					<Suspense key={`region-${suspenseKey}`} fallback={<FilterSkeleton />}>
+						<Regions country={country} region={region} />
+					</Suspense>
+				),
 			},
 			{
 				id: "year",
 				title: t("year"),
 				icon: Calendar,
-				renderComponent: () => <Years year={year} />,
+				renderComponent: () => (
+					<Suspense key={`year-${suspenseKey}`} fallback={<FilterSkeleton />}>
+						<Years year={year} />
+					</Suspense>
+				),
 			},
 			{
 				id: "allow-past-days",
 				title: t("allowPastDays.label"),
 				icon: ToggleLeftIcon,
-				renderComponent: () => <AllowPastDays allowPastDays={allowPastDays} />,
+				renderComponent: () => (
+					<Suspense key={`allow-past-days-${suspenseKey}`} fallback={<FilterSkeleton />}>
+						<AllowPastDays allowPastDays={allowPastDays} />
+					</Suspense>
+				),
 				renderTooltip: () => <AllowPasDaysInfoTooltip locale={locale} />,
 			},
 			{
 				id: "carry-over-months",
 				title: t("carryOverMonths.label"),
 				icon: SlidersHorizontal,
-				renderComponent: () => <CarryOverMonths carryOverMonths={carryOverMonths} />,
+				renderComponent: () => (
+					<Suspense key={`carry-over-months-${suspenseKey}`} fallback={<FilterSkeleton className="h-20" />}>
+						<CarryOverMonths carryOverMonths={carryOverMonths} />
+					</Suspense>
+				),
 				renderTooltip: () => <CarryOverMonthsTooltip locale={locale} />,
 			},
 		],
-		[country, region, ptoDays, year, allowPastDays, carryOverMonths, locale, t],
+		[country, region, ptoDays, year, allowPastDays, carryOverMonths, locale, t, suspenseKey],
 	);
 }

--- a/src/ui/modules/components/core/combobox/Combobox.tsx
+++ b/src/ui/modules/components/core/combobox/Combobox.tsx
@@ -2,7 +2,6 @@
 
 import type { CountryDTO } from "@application/dto/country/types";
 import type { RegionDTO } from "@application/dto/region/types";
-import { createQueryString } from "@modules/components/appSidebar/components/appSidebar/utils/createQueryString/createQueryString";
 import { hasFlag } from "@modules/components/core/combobox/utils/hasFlag/hasFlag";
 import { CommandEmpty } from "@modules/components/core/command/atoms/commandEmpty/CommandEmpty";
 import { CommandGroup } from "@modules/components/core/command/atoms/commandGroup/CommandGroup";
@@ -12,13 +11,13 @@ import { CommandList } from "@modules/components/core/command/atoms/commandList/
 import { PopoverContent } from "@modules/components/core/popover/atoms/popoverContent/PopoverContent";
 import { PopoverTrigger } from "@modules/components/core/popover/atoms/popoverTrigger/PopoverTrigger";
 import { Popover } from "@modules/components/core/popover/Popover";
+import { useFilterAction } from "@ui/hooks/useFilterAction/useFilterAction";
 import { Button } from "@ui/modules/components/core/button/Button";
 import { Command } from "@ui/modules/components/core/command/Command";
 import { mergeClasses } from "@ui/utils/mergeClasses/mergeClasses";
 import { Check, ChevronsUpDown } from "lucide-react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import type { HTMLProps } from "react";
-import { startTransition, useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 interface ComboboxProps extends HTMLProps<HTMLInputElement> {
 	searchPlaceholder?: string;
@@ -40,34 +39,23 @@ export const Combobox = ({
 	disabled,
 	type,
 }: ComboboxProps) => {
-	const router = useRouter();
-	const pathname = usePathname();
-	const searchParams = useSearchParams();
+	const { updateFilter, isPending } = useFilterAction();
 	const [isOpen, setIsOpen] = useState(false);
-	const [localValue, setLocalValue] = useState(value);
 
 	const selectedOption = useMemo(
-		() => options.find((option) => option.value.toLowerCase() === localValue.toLowerCase()),
-		[options, localValue],
+		() => options.find((option) => option.value.toLowerCase() === value.toLowerCase()),
+		[options, value],
 	);
 
 	const handleSelect = useCallback(
-		(currentValue: string) => {
-			const selectedOption = options.find((option) => option.label === currentValue);
+		(selectedLabel: string) => {
+			const selectedOption = options.find((option) => option.label === selectedLabel);
 			if (!selectedOption) return;
-			setLocalValue(selectedOption.value.toLowerCase());
 
-			const query = createQueryString({
-				value: selectedOption.value.toLowerCase(),
-				type,
-				searchParams,
-			});
-			startTransition(() => {
-				setIsOpen(false);
-				router.replace(`${pathname}?${query}`, { scroll: false });
-			});
+			setIsOpen(false);
+			updateFilter(type, selectedOption.value.toLowerCase());
 		},
-		[options, type, searchParams, pathname, router],
+		[options, type, updateFilter],
 	);
 
 	const commandItems = useMemo(
@@ -78,9 +66,9 @@ export const Combobox = ({
 					value={option?.label}
 					className={mergeClasses(
 						"hover:bg-slate-250 cursor-pointer rounded-md transition-colors duration-200",
-						localValue?.toLocaleLowerCase() === option.value.toLocaleLowerCase() && "bg-slate-250",
+						value?.toLowerCase() === option.value.toLowerCase() && "bg-slate-250",
 					)}
-					onSelect={(value) => handleSelect(value)}
+					onSelect={handleSelect}
 				>
 					<div className="flex w-full items-center gap-2">
 						{hasFlag(option) && <div className="relative h-4 w-6 overflow-hidden rounded">{option.flag}</div>}
@@ -89,12 +77,12 @@ export const Combobox = ({
 					<Check
 						className={mergeClasses(
 							"ml-auto h-4 w-4",
-							localValue?.toLocaleLowerCase() === option.value.toLocaleLowerCase() ? "opacity-100" : "opacity-0",
+							value?.toLowerCase() === option.value.toLowerCase() ? "opacity-100" : "opacity-0",
 						)}
 					/>
 				</CommandItem>
 			)),
-		[options, localValue, handleSelect],
+		[options, value, handleSelect],
 	);
 
 	const triggerContent = useMemo(() => {
@@ -112,12 +100,12 @@ export const Combobox = ({
 	}, [selectedOption, placeholder]);
 
 	return (
-		<div className="relative w-full">
+		<div className={`relative w-full ${isPending ? "opacity-50" : ""}`}>
 			<Popover open={isOpen} onOpenChange={setIsOpen}>
 				<PopoverTrigger asChild>
 					<Button
 						variant="outline"
-						disabled={disabled}
+						disabled={disabled || isPending}
 						aria-expanded={isOpen}
 						className={mergeClasses("w-full justify-between", className)}
 					>


### PR DESCRIPTION
This PR changes the approach when dealing with `router.push` events. Instead, it uses a server action to `redirect` + uses a `Suspense` boundary