### PR TITLE
feat: enable cache components

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.ts
+++ b/next.config.ts
@@ -72,6 +72,7 @@ const SECURITY_HEADERS = [
 
 const nextConfig: NextConfig = {
   poweredByHeader: false,
+  cacheComponents: true,
   compiler: {
     removeConsole: isProd,
   },

--- a/patches/boneyard-js.patch
+++ b/patches/boneyard-js.patch
@@ -1,0 +1,20 @@
+diff --git a/dist/react.js b/dist/react.js
+index 0ce974e11d9b1413b88346027a4c49ec1b81a043..3d8fcd5ea557b6c413150e7ff7ec570d9600fee7 100644
+--- a/dist/react.js
++++ b/dist/react.js	
+@@ -1,5 +1,5 @@
+ import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
+-import { Suspense, useRef, useState, useEffect, useLayoutEffect } from 'react';
++import { Suspense, useId, useRef, useState, useEffect, useLayoutEffect } from 'react';
+ import { normalizeBone } from './types.js';
+ import { adjustColor, ensureBuildSnapshotHook, getRegisteredBones, isBuildMode, registerBones, resolveResponsive, SHIMMER, PULSE, DEFAULTS, } from './shared.js';
+ ensureBuildSnapshotHook();
+@@ -31,7 +31,7 @@ export function configureBoneyard(config) {
+  */
+ export function Skeleton({ loading, children, name, initialBones, color, darkColor, animate, stagger = false, transition = false, boneClass, className, fallback, fixture, snapshotConfig, }) {
+     const containerRef = useRef(null);
+-    const uid = useRef(Math.random().toString(36).slice(2, 8)).current;
++    const uid = useId().replace(/[^a-zA-Z0-9-]/g, '');
+     const [containerWidth, setContainerWidth] = useState(0);
+     const [containerHeight, setContainerHeight] = useState(0);
+     const [isDark, setIsDark] = useState(false);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  boneyard-js: bb7a2d73c2746565d5f05e748e63a61ad9309329a9bd08f121e2d15fe2f7ea99
+
 importers:
 
   .:
@@ -43,7 +46,7 @@ importers:
         version: 1.2.3
       boneyard-js:
         specifier: 1.8.2
-        version: 1.8.2(react@19.2.7)(vite@8.0.14(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.16.9)(yaml@2.9.0))
+        version: 1.8.2(patch_hash=bb7a2d73c2746565d5f05e748e63a61ad9309329a9bd08f121e2d15fe2f7ea99)(react@19.2.7)(vite@8.0.14(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.16.9)(yaml@2.9.0))
       canvas-confetti:
         specifier: 1.9.4
         version: 1.9.4
@@ -8276,7 +8279,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  boneyard-js@1.8.2(react@19.2.7)(vite@8.0.14(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.16.9)(yaml@2.9.0)):
+  boneyard-js@1.8.2(patch_hash=bb7a2d73c2746565d5f05e748e63a61ad9309329a9bd08f121e2d15fe2f7ea99)(react@19.2.7)(vite@8.0.14(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.16.9)(yaml@2.9.0)):
     dependencies:
       playwright: 1.61.1
     optionalDependencies:
@@ -9706,7 +9709,7 @@ snapshots:
   normalize-package-data@8.0.0:
     dependencies:
       hosted-git-info: 9.0.3
-      semver: 7.8.1
+      semver: 7.8.5
       validate-npm-package-license: 3.0.4
 
   normalize-svg-path@1.1.0:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,3 +9,5 @@ allowBuilds:
   workerd: true
 minimumReleaseAge: 4320 # 3 days
 blockExoticSubdeps: true
+patchedDependencies:
+  boneyard-js: patches/boneyard-js.patch

--- a/src/app/.well-known/[...slug]/route.ts
+++ b/src/app/.well-known/[...slug]/route.ts
@@ -5,8 +5,6 @@ import { mcpServerCard } from '@infrastructure/well-known/mcpServerCard';
 import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { NextResponse } from 'next/server';
 
-export const dynamic = 'force-dynamic';
-
 type Handler = (baseUrl: string) => NextResponse;
 
 interface RouteContext {

--- a/src/app/[locale]/(app)/payment/confirmation/loading.tsx
+++ b/src/app/[locale]/(app)/payment/confirmation/loading.tsx
@@ -1,0 +1,9 @@
+import { Loader2 } from 'lucide-react';
+
+export default function Loading() {
+  return (
+    <div className='min-h-screen flex items-center justify-center p-4 bg-background'>
+      <Loader2 className='size-8 animate-spin text-muted-foreground' aria-hidden />
+    </div>
+  );
+}

--- a/src/app/[locale]/(app)/payment/confirmation/metadata.ts
+++ b/src/app/[locale]/(app)/payment/confirmation/metadata.ts
@@ -1,5 +1,5 @@
 import { localeAlternates, localePath } from '@infrastructure/i18n/utils/url';
-import { getCloudflareContext } from '@opennextjs/cloudflare';
+import { getPublicEnv } from '@infrastructure/services/env/getPublicEnv';
 import type { Metadata } from 'next';
 import type { Locale } from 'next-intl';
 import { getTranslations } from 'next-intl/server';
@@ -10,11 +10,10 @@ interface GenerateMetadataParams {
 
 export async function generateMetadata({ params }: GenerateMetadataParams): Promise<Metadata> {
   const { locale } = await params;
-  const [{ env }, t] = await Promise.all([
-    getCloudflareContext({ async: true }),
+  const [{ siteUrl: baseUrl }, t] = await Promise.all([
+    getPublicEnv(),
     getTranslations({ locale, namespace: 'metadata.paymentConfirmation' }),
   ]);
-  const baseUrl = env.NEXT_PUBLIC_SITE_URL;
 
   return {
     title: t('title'),

--- a/src/app/[locale]/(app)/payment/confirmation/page.tsx
+++ b/src/app/[locale]/(app)/payment/confirmation/page.tsx
@@ -7,13 +7,11 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@ui/m
 import { getCurrencySymbol } from '@ui/utils/currencies';
 import { Effect } from 'effect';
 import { CheckCircle2, XCircle } from 'lucide-react';
+import { redirect } from 'next/navigation';
 import type { Locale } from 'next-intl';
 import { getTranslations } from 'next-intl/server';
-import { redirect } from 'next/navigation';
 
 export { generateMetadata } from './metadata';
-
-export const dynamic = 'force-dynamic';
 
 interface PaymentSuccessParams {
   searchParams: Promise<{
@@ -65,9 +63,7 @@ export default async function PaymentSuccessPage({ searchParams, params }: Reado
     redirect(`/${locale}`);
   }
 
-  const data = await Effect.runPromise(
-    confirmation(paymentIntentId).pipe(Effect.provide(ApplicationLayer)),
-  );
+  const data = await Effect.runPromise(confirmation(paymentIntentId).pipe(Effect.provide(ApplicationLayer)));
 
   if (!data || data.status !== 'succeeded') {
     if (data) {

--- a/src/app/[locale]/(app)/planner/metadata.ts
+++ b/src/app/[locale]/(app)/planner/metadata.ts
@@ -1,5 +1,5 @@
 import { localeAlternates, localePath } from '@infrastructure/i18n/utils/url';
-import { getCloudflareContext } from '@opennextjs/cloudflare';
+import { getPublicEnv } from '@infrastructure/services/env/getPublicEnv';
 import type { Metadata } from 'next';
 import type { Locale } from 'next-intl';
 import { getTranslations } from 'next-intl/server';
@@ -10,11 +10,10 @@ interface GenerateMetadataParams {
 
 export async function generateMetadata({ params }: GenerateMetadataParams): Promise<Metadata> {
   const { locale } = await params;
-  const [{ env }, t] = await Promise.all([
-    getCloudflareContext({ async: true }),
+  const [{ siteUrl: baseUrl }, t] = await Promise.all([
+    getPublicEnv(),
     getTranslations({ locale, namespace: 'metadata' }),
   ]);
-  const baseUrl = env.NEXT_PUBLIC_SITE_URL;
 
   return {
     title: t('planner.title'),

--- a/src/app/[locale]/(marketing)/legal/cookie-policy/metadata.ts
+++ b/src/app/[locale]/(marketing)/legal/cookie-policy/metadata.ts
@@ -1,5 +1,5 @@
 import { localeAlternates, localePath } from '@infrastructure/i18n/utils/url';
-import { getCloudflareContext } from '@opennextjs/cloudflare';
+import { getPublicEnv } from '@infrastructure/services/env/getPublicEnv';
 import type { Metadata } from 'next';
 import type { Locale } from 'next-intl';
 import { getTranslations } from 'next-intl/server';
@@ -10,11 +10,10 @@ interface GenerateMetadataParams {
 
 export async function generateMetadata({ params }: GenerateMetadataParams): Promise<Metadata> {
   const { locale } = await params;
-  const [{ env }, t] = await Promise.all([
-    getCloudflareContext({ async: true }),
+  const [{ siteUrl: baseUrl }, t] = await Promise.all([
+    getPublicEnv(),
     getTranslations({ locale, namespace: 'metadata.cookiePolicy' }),
   ]);
-  const baseUrl = env.NEXT_PUBLIC_SITE_URL;
 
   return {
     title: t('title'),

--- a/src/app/[locale]/(marketing)/legal/cookie-policy/page.tsx
+++ b/src/app/[locale]/(marketing)/legal/cookie-policy/page.tsx
@@ -1,7 +1,7 @@
-import { addDays, startOfToday } from '@application/shared/utils/dates';
-import { getCloudflareContext } from '@opennextjs/cloudflare';
+import { getPublicEnv } from '@infrastructure/services/env/getPublicEnv';
 import { createRichLink } from '@ui/modules/core/primitives/RichLink';
 import { LegalLayout } from '@ui/modules/layout/LegalLayout';
+import { getLastUpdatedDate } from '@ui/utils/getLastUpdatedDate';
 import type { Locale } from 'next-intl';
 import { getTranslations } from 'next-intl/server';
 
@@ -13,16 +13,12 @@ interface CookiePolicyPageProps {
 
 export default async function CookiePolicyPage({ params }: Readonly<CookiePolicyPageProps>) {
   const { locale } = await params;
-  const [{ env }, t] = await Promise.all([
-    getCloudflareContext({ async: true }),
+  const [{ siteUrl, contactEmail }, t] = await Promise.all([
+    getPublicEnv(),
     getTranslations({ locale, namespace: 'cookiePolicy' }),
   ]);
-  const siteLink = createRichLink(env.NEXT_PUBLIC_SITE_URL);
-  const lastUpdatedDate = addDays(startOfToday(), -7).toLocaleDateString(locale, {
-    day: 'numeric',
-    month: 'long',
-    year: 'numeric',
-  });
+  const siteLink = createRichLink(siteUrl);
+  const lastUpdatedDate = getLastUpdatedDate(locale);
 
   return (
     <LegalLayout title={t('title')} lastUpdated={t('lastUpdated', { date: lastUpdatedDate })}>
@@ -225,11 +221,10 @@ export default async function CookiePolicyPage({ params }: Readonly<CookiePolicy
         <ul className='list-disc pl-6 mt-2 space-y-2'>
           <li>
             <strong>{t('sections.contact.email.label')}</strong>{' '}
-            {t('sections.contact.email.value', { supportEmail: env.NEXT_PUBLIC_CONTACT_EMAIL })}
+            {t('sections.contact.email.value', { supportEmail: contactEmail })}
           </li>
           <li>
-            <strong>{t('sections.contact.website.label')}</strong>{' '}
-            {t('sections.contact.website.value', { siteUrl: env.NEXT_PUBLIC_SITE_URL })}
+            <strong>{t('sections.contact.website.label')}</strong> {t('sections.contact.website.value', { siteUrl })}
           </li>
         </ul>
       </section>

--- a/src/app/[locale]/(marketing)/legal/legal-notice/metadata.ts
+++ b/src/app/[locale]/(marketing)/legal/legal-notice/metadata.ts
@@ -1,5 +1,5 @@
 import { localeAlternates, localePath } from '@infrastructure/i18n/utils/url';
-import { getCloudflareContext } from '@opennextjs/cloudflare';
+import { getPublicEnv } from '@infrastructure/services/env/getPublicEnv';
 import type { Metadata } from 'next';
 import type { Locale } from 'next-intl';
 import { getTranslations } from 'next-intl/server';
@@ -10,11 +10,10 @@ interface GenerateMetadataParams {
 
 export async function generateMetadata({ params }: GenerateMetadataParams): Promise<Metadata> {
   const { locale } = await params;
-  const [{ env }, t] = await Promise.all([
-    getCloudflareContext({ async: true }),
+  const [{ siteUrl: baseUrl }, t] = await Promise.all([
+    getPublicEnv(),
     getTranslations({ locale, namespace: 'metadata.legalNotice' }),
   ]);
-  const baseUrl = env.NEXT_PUBLIC_SITE_URL;
 
   return {
     title: t('title'),

--- a/src/app/[locale]/(marketing)/legal/legal-notice/page.tsx
+++ b/src/app/[locale]/(marketing)/legal/legal-notice/page.tsx
@@ -1,10 +1,10 @@
-import { addDays, startOfToday } from '@application/shared/utils/dates';
-import { getCloudflareContext } from '@opennextjs/cloudflare';
+import { getPublicEnv } from '@infrastructure/services/env/getPublicEnv';
 import { createRichLink } from '@ui/modules/core/primitives/RichLink';
 import { LegalLayout } from '@ui/modules/layout/LegalLayout';
 import { Address } from '@ui/modules/pages/legal/Address';
 import { Me } from '@ui/modules/pages/legal/Me';
 import { Nif } from '@ui/modules/pages/legal/Nif';
+import { getLastUpdatedDate } from '@ui/utils/getLastUpdatedDate';
 
 const githubLink = createRichLink('https://github.com/fbuireu/forever-pto', { external: true });
 
@@ -19,15 +19,11 @@ interface LegalNoticePageProps {
 
 export default async function LegalNoticePage({ params }: LegalNoticePageProps) {
   const { locale } = await params;
-  const [{ env }, t] = await Promise.all([
-    getCloudflareContext({ async: true }),
+  const [{ siteUrl, contactEmail }, t] = await Promise.all([
+    getPublicEnv(),
     getTranslations({ locale, namespace: 'legalNotice' }),
   ]);
-  const lastUpdatedDate = addDays(startOfToday(), -7).toLocaleDateString(locale, {
-    day: 'numeric',
-    month: 'long',
-    year: 'numeric',
-  });
+  const lastUpdatedDate = getLastUpdatedDate(locale);
 
   return (
     <LegalLayout title={t('title')} lastUpdated={t('lastUpdated', { date: lastUpdatedDate })}>
@@ -55,11 +51,11 @@ export default async function LegalNoticePage({ params }: LegalNoticePageProps) 
           </li>
           <li>
             <strong>{t('sections.identification.items.email.label')}</strong>{' '}
-            {t('sections.identification.items.email.value', { supportEmail: env.NEXT_PUBLIC_CONTACT_EMAIL })}
+            {t('sections.identification.items.email.value', { supportEmail: contactEmail })}
           </li>
           <li>
             <strong>{t('sections.identification.items.website.label')}</strong>{' '}
-            {t('sections.identification.items.website.value', { siteUrl: env.NEXT_PUBLIC_SITE_URL })}
+            {t('sections.identification.items.website.value', { siteUrl })}
           </li>
         </ul>
       </section>
@@ -136,7 +132,7 @@ export default async function LegalNoticePage({ params }: LegalNoticePageProps) 
         <ul className='list-disc pl-6 mt-2 space-y-2'>
           <li>
             <strong>{t('sections.contact.items.email.label')}</strong>{' '}
-            {t('sections.contact.items.email.value', { supportEmail: env.NEXT_PUBLIC_CONTACT_EMAIL })}
+            {t('sections.contact.items.email.value', { supportEmail: contactEmail })}
           </li>
         </ul>
       </section>

--- a/src/app/[locale]/(marketing)/legal/privacy-policy/metadata.ts
+++ b/src/app/[locale]/(marketing)/legal/privacy-policy/metadata.ts
@@ -1,5 +1,5 @@
 import { localeAlternates, localePath } from '@infrastructure/i18n/utils/url';
-import { getCloudflareContext } from '@opennextjs/cloudflare';
+import { getPublicEnv } from '@infrastructure/services/env/getPublicEnv';
 import type { Metadata } from 'next';
 import type { Locale } from 'next-intl';
 import { getTranslations } from 'next-intl/server';
@@ -10,11 +10,10 @@ interface GenerateMetadataParams {
 
 export async function generateMetadata({ params }: GenerateMetadataParams): Promise<Metadata> {
   const { locale } = await params;
-  const [{ env }, t] = await Promise.all([
-    getCloudflareContext({ async: true }),
+  const [{ siteUrl: baseUrl }, t] = await Promise.all([
+    getPublicEnv(),
     getTranslations({ locale, namespace: 'metadata.privacyPolicy' }),
   ]);
-  const baseUrl = env.NEXT_PUBLIC_SITE_URL;
 
   return {
     title: t('title'),

--- a/src/app/[locale]/(marketing)/legal/privacy-policy/page.tsx
+++ b/src/app/[locale]/(marketing)/legal/privacy-policy/page.tsx
@@ -1,11 +1,11 @@
-import { addDays, startOfToday } from '@application/shared/utils/dates';
-import { getCloudflareContext } from '@opennextjs/cloudflare';
+import { getPublicEnv } from '@infrastructure/services/env/getPublicEnv';
 import { createRichLink } from '@ui/modules/core/primitives/RichLink';
 
 const cookiePolicyLink = createRichLink('/legal/cookie-policy');
 
 import { LegalLayout } from '@ui/modules/layout/LegalLayout';
 import { Me } from '@ui/modules/pages/legal/Me';
+import { getLastUpdatedDate } from '@ui/utils/getLastUpdatedDate';
 import type { Locale } from 'next-intl';
 import { getTranslations } from 'next-intl/server';
 
@@ -17,15 +17,11 @@ interface PrivacyPolicyPageProps {
 
 export default async function PrivacyPolicyPage({ params }: Readonly<PrivacyPolicyPageProps>) {
   const { locale } = await params;
-  const [{ env }, t] = await Promise.all([
-    getCloudflareContext({ async: true }),
+  const [{ siteUrl, contactEmail }, t] = await Promise.all([
+    getPublicEnv(),
     getTranslations({ locale, namespace: 'privacyPolicy' }),
   ]);
-  const lastUpdatedDate = addDays(startOfToday(), -7).toLocaleDateString(locale, {
-    day: 'numeric',
-    month: 'long',
-    year: 'numeric',
-  });
+  const lastUpdatedDate = getLastUpdatedDate(locale);
 
   return (
     <LegalLayout title={t('title')} lastUpdated={t('lastUpdated', { date: lastUpdatedDate })}>
@@ -47,11 +43,11 @@ export default async function PrivacyPolicyPage({ params }: Readonly<PrivacyPoli
           </li>
           <li>
             <strong>{t('sections.dataController.items.email.label')}</strong>{' '}
-            {t('sections.dataController.items.email.value', { supportEmail: env.NEXT_PUBLIC_CONTACT_EMAIL })}
+            {t('sections.dataController.items.email.value', { supportEmail: contactEmail })}
           </li>
           <li>
             <strong>{t('sections.dataController.items.website.label')}</strong>{' '}
-            {t('sections.dataController.items.website.value', { siteUrl: env.NEXT_PUBLIC_SITE_URL })}
+            {t('sections.dataController.items.website.value', { siteUrl })}
           </li>
         </ul>
       </section>
@@ -239,7 +235,7 @@ export default async function PrivacyPolicyPage({ params }: Readonly<PrivacyPoli
             {t('sections.yourRights.items.complaint.description')}
           </li>
         </ul>
-        <p className='mt-4'>{t('sections.yourRights.contact', { supportEmail: env.NEXT_PUBLIC_CONTACT_EMAIL })}</p>
+        <p className='mt-4'>{t('sections.yourRights.contact', { supportEmail: contactEmail })}</p>
       </section>
 
       <section>
@@ -272,11 +268,11 @@ export default async function PrivacyPolicyPage({ params }: Readonly<PrivacyPoli
         <ul className='list-disc pl-6 mt-4 space-y-2'>
           <li>
             <strong>{t('sections.contactInfo.items.email.label')}</strong>{' '}
-            {t('sections.contactInfo.items.email.value', { supportEmail: env.NEXT_PUBLIC_CONTACT_EMAIL })}
+            {t('sections.contactInfo.items.email.value', { supportEmail: contactEmail })}
           </li>
           <li>
             <strong>{t('sections.contactInfo.items.website.label')}</strong>{' '}
-            {t('sections.contactInfo.items.website.value', { siteUrl: env.NEXT_PUBLIC_SITE_URL })}
+            {t('sections.contactInfo.items.website.value', { siteUrl })}
           </li>
         </ul>
         <p className='mt-4'>{t('sections.contactInfo.responseTime')}</p>

--- a/src/app/[locale]/(marketing)/legal/terms-of-service/metadata.ts
+++ b/src/app/[locale]/(marketing)/legal/terms-of-service/metadata.ts
@@ -1,5 +1,5 @@
 import { localeAlternates, localePath } from '@infrastructure/i18n/utils/url';
-import { getCloudflareContext } from '@opennextjs/cloudflare';
+import { getPublicEnv } from '@infrastructure/services/env/getPublicEnv';
 import type { Metadata } from 'next';
 import type { Locale } from 'next-intl';
 import { getTranslations } from 'next-intl/server';
@@ -10,11 +10,10 @@ interface GenerateMetadataParams {
 
 export async function generateMetadata({ params }: GenerateMetadataParams): Promise<Metadata> {
   const { locale } = await params;
-  const [{ env }, t] = await Promise.all([
-    getCloudflareContext({ async: true }),
+  const [{ siteUrl: baseUrl }, t] = await Promise.all([
+    getPublicEnv(),
     getTranslations({ locale, namespace: 'metadata.termsOfService' }),
   ]);
-  const baseUrl = env.NEXT_PUBLIC_SITE_URL;
 
   return {
     title: t('title'),

--- a/src/app/[locale]/(marketing)/legal/terms-of-service/page.tsx
+++ b/src/app/[locale]/(marketing)/legal/terms-of-service/page.tsx
@@ -1,7 +1,7 @@
-import { addDays, startOfToday } from '@application/shared/utils/dates';
-import { getCloudflareContext } from '@opennextjs/cloudflare';
+import { getPublicEnv } from '@infrastructure/services/env/getPublicEnv';
 import { createRichLink } from '@ui/modules/core/primitives/RichLink';
 import { LegalLayout } from '@ui/modules/layout/LegalLayout';
+import { getLastUpdatedDate } from '@ui/utils/getLastUpdatedDate';
 import type { Locale } from 'next-intl';
 
 const githubLink = createRichLink('https://github.com/fbuireu/forever-pto', { external: true });
@@ -17,15 +17,11 @@ interface TermsOfServicePageProps {
 
 export default async function TermsOfServicePage({ params }: Readonly<TermsOfServicePageProps>) {
   const { locale } = await params;
-  const [{ env }, t] = await Promise.all([
-    getCloudflareContext({ async: true }),
+  const [{ siteUrl, contactEmail }, t] = await Promise.all([
+    getPublicEnv(),
     getTranslations({ locale, namespace: 'termsOfService' }),
   ]);
-  const lastUpdatedDate = addDays(startOfToday(), -7).toLocaleDateString(locale, {
-    day: 'numeric',
-    month: 'long',
-    year: 'numeric',
-  });
+  const lastUpdatedDate = getLastUpdatedDate(locale);
 
   return (
     <LegalLayout title={t('title')} lastUpdated={t('lastUpdated', { date: lastUpdatedDate })}>
@@ -130,7 +126,7 @@ export default async function TermsOfServicePage({ params }: Readonly<TermsOfSer
         <h3 className='text-xl font-semibold mt-6 mb-3'>{t('sections.refundPolicy.process.title')}</h3>
         <p>{t('sections.refundPolicy.process.description')}</p>
         <ol className='list-decimal pl-6 mt-2 space-y-2'>
-          <li>{t('sections.refundPolicy.process.steps.contact', { supportEmail: env.NEXT_PUBLIC_CONTACT_EMAIL })}</li>
+          <li>{t('sections.refundPolicy.process.steps.contact', { supportEmail: contactEmail })}</li>
           <li>{t('sections.refundPolicy.process.steps.include')}</li>
           <li>{t('sections.refundPolicy.process.steps.review')}</li>
           <li>{t('sections.refundPolicy.process.steps.processing')}</li>
@@ -286,9 +282,7 @@ export default async function TermsOfServicePage({ params }: Readonly<TermsOfSer
         <p>{t('sections.governingLaw.jurisdiction.description')}</p>
 
         <h3 className='text-xl font-semibold mt-6 mb-3'>{t('sections.governingLaw.disputeResolution.title')}</h3>
-        <p>
-          {t('sections.governingLaw.disputeResolution.description', { supportEmail: env.NEXT_PUBLIC_CONTACT_EMAIL })}
-        </p>
+        <p>{t('sections.governingLaw.disputeResolution.description', { supportEmail: contactEmail })}</p>
 
         <h3 className='text-xl font-semibold mt-6 mb-3'>{t('sections.governingLaw.euOdr.title')}</h3>
         <p>{t.rich('sections.governingLaw.euOdr.description', { link: odrLink })}</p>
@@ -321,11 +315,11 @@ export default async function TermsOfServicePage({ params }: Readonly<TermsOfSer
         <ul className='list-disc pl-6 mt-4 space-y-2'>
           <li>
             <strong>{t('sections.contactInfo.items.email.label')}</strong>{' '}
-            {t('sections.contactInfo.items.email.value', { supportEmail: env.NEXT_PUBLIC_CONTACT_EMAIL })}
+            {t('sections.contactInfo.items.email.value', { supportEmail: contactEmail })}
           </li>
           <li>
             <strong>{t('sections.contactInfo.items.website.label')}</strong>{' '}
-            {t('sections.contactInfo.items.website.value', { siteUrl: env.NEXT_PUBLIC_SITE_URL })}
+            {t('sections.contactInfo.items.website.value', { siteUrl })}
           </li>
         </ul>
         <p className='mt-4'>{t('sections.contactInfo.responseTime')}</p>

--- a/src/app/[locale]/(marketing)/metadata.ts
+++ b/src/app/[locale]/(marketing)/metadata.ts
@@ -1,5 +1,5 @@
 import { localeAlternates, localePath } from '@infrastructure/i18n/utils/url';
-import { getCloudflareContext } from '@opennextjs/cloudflare';
+import { getPublicEnv } from '@infrastructure/services/env/getPublicEnv';
 import type { Metadata } from 'next';
 import type { Locale } from 'next-intl';
 import { getTranslations } from 'next-intl/server';
@@ -10,11 +10,10 @@ interface GenerateMetadataParams {
 
 export async function generateMetadata({ params }: GenerateMetadataParams): Promise<Metadata> {
   const { locale } = await params;
-  const [{ env }, t] = await Promise.all([
-    getCloudflareContext({ async: true }),
+  const [{ siteUrl: baseUrl }, t] = await Promise.all([
+    getPublicEnv(),
     getTranslations({ locale, namespace: 'metadata' }),
   ]);
-  const baseUrl = env.NEXT_PUBLIC_SITE_URL;
 
   return {
     title: t('title'),

--- a/src/app/[locale]/(marketing)/page.tsx
+++ b/src/app/[locale]/(marketing)/page.tsx
@@ -35,7 +35,7 @@ const HomePage = async ({ params }: PageProps) => {
       <Stats />
       <Features />
       <Comparison />
-      <Testimonials />
+      <Testimonials locale={locale} />
       <Pricing />
       <Faq />
       <HomepageCta />

--- a/src/app/api/markdown/route.ts
+++ b/src/app/api/markdown/route.ts
@@ -1,8 +1,6 @@
 import { buildMarkdownPage } from '@infrastructure/markdown/buildMarkdownPage';
 import { getCloudflareContext } from '@opennextjs/cloudflare';
 
-export const dynamic = 'force-dynamic';
-
 export async function GET(request: Request) {
   const { env } = await getCloudflareContext({ async: true });
   const baseUrl = env.NEXT_PUBLIC_SITE_URL;

--- a/src/app/global-not-found.tsx
+++ b/src/app/global-not-found.tsx
@@ -4,12 +4,14 @@ import { LOCALE_COOKIE } from '@infrastructure/i18n/config';
 import { LOCALES } from '@infrastructure/i18n/locales';
 import { routing } from '@infrastructure/i18n/routing';
 import { LazyMotionProvider } from '@ui/modules/core/animate/providers/LazyMotionProvider';
+import { HtmlLangSync } from '@ui/modules/pages/not-found/HtmlLangSync';
 import { NotFoundContent } from '@ui/modules/pages/not-found/NotFoundContent';
 import { AppThemeProvider } from '@ui/modules/providers/AppThemeProvider';
 import { cn } from '@ui/utils/cn';
 import { cookies, headers } from 'next/headers';
 import { hasLocale, NextIntlClientProvider } from 'next-intl';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
+import { Suspense } from 'react';
 
 async function detectLocale() {
   const [headersList, cookieStore] = await Promise.all([headers(), cookies()]);
@@ -29,13 +31,34 @@ async function detectLocale() {
   return routing.defaultLocale;
 }
 
-export default async function GlobalNotFound() {
+const LocalizedNotFound = async () => {
   const locale = await detectLocale();
   setRequestLocale(locale);
   const t = await getTranslations({ locale, namespace: 'accessibility' });
 
   return (
-    <html lang={locale} suppressHydrationWarning>
+    <>
+      <HtmlLangSync locale={locale} />
+      <a
+        href='#main-content'
+        className='sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-3 focus:py-1.5 focus:text-sm focus:bg-background focus:text-foreground focus:border focus:rounded-md focus:shadow-sm'
+      >
+        {t('skipToMainContent')}
+      </a>
+      <NextIntlClientProvider>
+        <AppThemeProvider>
+          <LazyMotionProvider>
+            <NotFoundContent locale={locale} />
+          </LazyMotionProvider>
+        </AppThemeProvider>
+      </NextIntlClientProvider>
+    </>
+  );
+};
+
+export default function GlobalNotFound() {
+  return (
+    <html lang={routing.defaultLocale} suppressHydrationWarning>
       <body
         className={cn(
           bricolage.variable,
@@ -45,19 +68,9 @@ export default async function GlobalNotFound() {
           'font-sans antialiased'
         )}
       >
-        <a
-          href='#main-content'
-          className='sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-3 focus:py-1.5 focus:text-sm focus:bg-background focus:text-foreground focus:border focus:rounded-md focus:shadow-sm'
-        >
-          {t('skipToMainContent')}
-        </a>
-        <NextIntlClientProvider>
-          <AppThemeProvider>
-            <LazyMotionProvider>
-              <NotFoundContent locale={locale} />
-            </LazyMotionProvider>
-          </AppThemeProvider>
-        </NextIntlClientProvider>
+        <Suspense fallback={null}>
+          <LocalizedNotFound />
+        </Suspense>
       </body>
     </html>
   );

--- a/src/infrastructure/services/env/getPublicEnv.ts
+++ b/src/infrastructure/services/env/getPublicEnv.ts
@@ -1,0 +1,18 @@
+import { getCloudflareContext } from '@opennextjs/cloudflare';
+import { cacheLife } from 'next/cache';
+
+interface PublicEnv {
+  siteUrl: string;
+  contactEmail: string;
+}
+
+export async function getPublicEnv(): Promise<PublicEnv> {
+  'use cache';
+  cacheLife('days');
+  const { env } = await getCloudflareContext({ async: true });
+
+  return {
+    siteUrl: env.NEXT_PUBLIC_SITE_URL,
+    contactEmail: env.NEXT_PUBLIC_CONTACT_EMAIL,
+  };
+}

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -28,11 +28,11 @@ const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL;
 
 const { middleware } = await import('./middleware');
 
-function makeRequest(pathname: string, accept = ''): NextRequest {
+function makeRequest(pathname: string, accept = '', search = ''): NextRequest {
   return {
     headers: { get: (key: string) => (key === 'accept' ? accept : null) },
-    nextUrl: { pathname },
-    url: `${BASE_URL}${pathname}`,
+    nextUrl: { pathname, searchParams: new URLSearchParams(search) },
+    url: `${BASE_URL}${pathname}${search ? `?${search}` : ''}`,
   } as unknown as NextRequest;
 }
 
@@ -76,6 +76,65 @@ describe('middleware', () => {
     it('does not rewrite non-markdown requests', async () => {
       const spy = vi.spyOn(NextResponse, 'rewrite');
       const request = makeRequest('/some-page', 'text/html');
+
+      await middleware(request);
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('sets public Cache-Control on the markdown rewrite response', async () => {
+      const request = makeRequest('/some-page', 'text/markdown');
+
+      const response = await middleware(request);
+
+      expect(response.headers.get('Cache-Control')).toBe('public, max-age=3600');
+    });
+  });
+
+  describe('markdown api cache header', () => {
+    it('sets public Cache-Control for direct /api/markdown requests', async () => {
+      const request = makeRequest('/api/markdown', '', 'path=/');
+
+      const response = await middleware(request);
+
+      expect(response.headers.get('Cache-Control')).toBe('public, max-age=3600');
+    });
+
+    it('does not run the i18n proxy for /api/markdown requests', async () => {
+      const request = makeRequest('/api/markdown', '', 'path=/');
+
+      await middleware(request);
+
+      expect(mockI18nProxy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('payment confirmation redirect', () => {
+    it('redirects /payment/confirmation to home when payment_intent is missing', async () => {
+      const spy = vi.spyOn(NextResponse, 'redirect');
+      const request = makeRequest('/payment/confirmation');
+
+      await middleware(request);
+
+      expect(spy).toHaveBeenCalledOnce();
+      const url = spy.mock.calls[0][0] as URL;
+      expect(url.pathname).toBe('/');
+    });
+
+    it('redirects locale-prefixed confirmation to the locale home when payment_intent is missing', async () => {
+      const spy = vi.spyOn(NextResponse, 'redirect');
+      const request = makeRequest(`/${ES}/payment/confirmation`);
+
+      await middleware(request);
+
+      expect(spy).toHaveBeenCalledOnce();
+      const url = spy.mock.calls[0][0] as URL;
+      expect(url.pathname).toBe(`/${ES}`);
+    });
+
+    it('does not redirect when payment_intent is present', async () => {
+      const spy = vi.spyOn(NextResponse, 'redirect');
+      const request = makeRequest('/payment/confirmation', '', 'payment_intent=pi_123&redirect_status=succeeded');
 
       await middleware(request);
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,17 +7,39 @@ import createMiddleware from 'next-intl/middleware';
 
 const i18nProxy = createMiddleware(routing);
 
+const PAYMENT_CONFIRMATION_PATH = '/payment/confirmation';
+// Under cacheComponents, Next.js stamps dynamic route-handler responses with a no-store
+// Cache-Control that replaces the handler's own header; middleware response headers are
+// applied after the render, so the intended caching policy is restored here.
+const MARKDOWN_CACHE_CONTROL = 'public, max-age=3600';
+
 export async function middleware(request: NextRequest): Promise<NextResponse> {
   const accept = request.headers.get('accept') ?? '';
   const pathname = request.nextUrl.pathname;
   const isMarkdownRequest = accept.includes('text/markdown');
   const isInternalPath = pathname.startsWith('/api/') || pathname.startsWith('/.well-known/');
 
+  if (pathname === '/api/markdown') {
+    const response = NextResponse.next();
+    response.headers.set('Cache-Control', MARKDOWN_CACHE_CONTROL);
+    return response;
+  }
+
   if (isMarkdownRequest && !isInternalPath) {
     const markdownUrl = new URL('/api/markdown', request.url);
     markdownUrl.searchParams.set('path', pathname);
 
-    return NextResponse.rewrite(markdownUrl);
+    const response = NextResponse.rewrite(markdownUrl);
+    response.headers.set('Cache-Control', MARKDOWN_CACHE_CONTROL);
+    return response;
+  }
+
+  // redirect() inside the PPR page streams after the 200 static shell instead of returning
+  // an HTTP 3xx, so the missing-param guard must answer at the proxy level.
+  if (pathname.endsWith(PAYMENT_CONFIRMATION_PATH) && !request.nextUrl.searchParams.has('payment_intent')) {
+    const homePath = pathname.slice(0, -PAYMENT_CONFIRMATION_PATH.length) || '/';
+
+    return NextResponse.redirect(new URL(homePath, request.url));
   }
 
   const i18nResponse = i18nProxy(request);
@@ -31,5 +53,5 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
 }
 
 export const config = {
-  matcher: ['/((?!api|_next|_vercel|.*\\..*).*)'],
+  matcher: ['/((?!api|_next|_vercel|.*\\..*).*)', '/api/markdown'],
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,9 +8,6 @@ import createMiddleware from 'next-intl/middleware';
 const i18nProxy = createMiddleware(routing);
 
 const PAYMENT_CONFIRMATION_PATH = '/payment/confirmation';
-// Under cacheComponents, Next.js stamps dynamic route-handler responses with a no-store
-// Cache-Control that replaces the handler's own header; middleware response headers are
-// applied after the render, so the intended caching policy is restored here.
 const MARKDOWN_CACHE_CONTROL = 'public, max-age=3600';
 
 export async function middleware(request: NextRequest): Promise<NextResponse> {
@@ -34,8 +31,6 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
     return response;
   }
 
-  // redirect() inside the PPR page streams after the 200 static shell instead of returning
-  // an HTTP 3xx, so the missing-param guard must answer at the proxy level.
   if (pathname.endsWith(PAYMENT_CONFIRMATION_PATH) && !request.nextUrl.searchParams.has('payment_intent')) {
     const homePath = pathname.slice(0, -PAYMENT_CONFIRMATION_PATH.length) || '/';
 

--- a/src/ui/modules/core/animate/base/Sidebar.tsx
+++ b/src/ui/modules/core/animate/base/Sidebar.tsx
@@ -1,13 +1,23 @@
 'use client';
 
 import { useIsMobile } from '@ui/hooks/useMobile';
-import { setCookie } from '@ui/utils/cookie';
 import { Button } from '@ui/modules/core/primitives/Button';
 import { cn } from '@ui/utils/cn';
+import { setCookie } from '@ui/utils/cookie';
 import type { VariantProps } from 'class-variance-authority';
 import { cva } from 'class-variance-authority';
 import { AnimatePresence, m, type Transition } from 'motion/react';
-import { type ComponentProps, type CSSProperties, type MouseEvent, createContext, use, useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  type ComponentProps,
+  type CSSProperties,
+  createContext,
+  type MouseEvent,
+  use,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { MotionHighlight, MotionHighlightItem } from '../effects/MotionHighlight';
 import { PanelLeftIcon } from '../icons/PanelLeft';
 import { Slot } from './Slot';
@@ -68,7 +78,9 @@ function SidebarProvider({
       } else {
         setInternalOpen(openState);
       }
-      setCookie({ name: SIDEBAR_COOKIE_NAME, value: String(openState), maxAge: SIDEBAR_COOKIE_MAX_AGE }).catch(() => {});
+      setCookie({ name: SIDEBAR_COOKIE_NAME, value: String(openState), maxAge: SIDEBAR_COOKIE_MAX_AGE }).catch(
+        () => {}
+      );
     },
     [setOpenProp, open]
   );
@@ -76,6 +88,14 @@ function SidebarProvider({
   const toggleSidebar = useCallback(() => {
     return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
   }, [isMobile, setOpen]);
+
+  useEffect(() => {
+    if (openProp !== undefined) return;
+    const match = document.cookie.match(new RegExp(`(?:^|; )${SIDEBAR_COOKIE_NAME}=([^;]*)`));
+    if (match) {
+      setInternalOpen(match[1] !== 'false');
+    }
+  }, [openProp]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -379,10 +399,7 @@ function SidebarGroup({ className, ...props }: SidebarGroupProps) {
     <div
       data-slot='sidebar-group'
       data-sidebar='group'
-      className={cn(
-        'relative flex w-full min-w-0 flex-col rounded-xl bg-(--surface-panel-inset) p-2.5',
-        className
-      )}
+      className={cn('relative flex w-full min-w-0 flex-col rounded-xl bg-(--surface-panel-inset) p-2.5', className)}
       {...props}
     />
   );

--- a/src/ui/modules/pages/homepage/sections/Hero.tsx
+++ b/src/ui/modules/pages/homepage/sections/Hero.tsx
@@ -1,4 +1,3 @@
-import type { ReactNode } from 'react';
 import { Link } from '@application/i18n/navigation';
 import { getWeekdayNames } from '@application/shared/utils/dates';
 import { LOCALES } from '@infrastructure/i18n/locales';
@@ -7,7 +6,9 @@ import { Button } from '@ui/modules/core/primitives/Button';
 import { FlagIcon } from '@ui/modules/core/primitives/FlagIcon';
 import { MODIFIERS_CLASS_NAMES } from '@ui/modules/pages/planner/calendar/utils/helpers';
 import { cn } from '@ui/utils/cn';
+import { getCurrentYear } from '@ui/utils/getCurrentYear';
 import { getLocale, getTranslations } from 'next-intl/server';
+import type { ReactNode } from 'react';
 import { version } from '../../../../../../package.json';
 import { CAL_ENTRIES, type DayType } from './shared';
 
@@ -22,9 +23,9 @@ const HERO_DAY_CLASS: Record<DayType, string> = {
 };
 
 export const Hero = async () => {
-  const [t, locale] = await Promise.all([getTranslations('homepage'), getLocale()]);
-  const DAY_HEADERS = getWeekdayNames({ locale, weekStartsOn: 1, format: 'narrow' }).map((label) => ({
-    id: crypto.randomUUID(),
+  const [t, locale, year] = await Promise.all([getTranslations('homepage'), getLocale(), getCurrentYear()]);
+  const DAY_HEADERS = getWeekdayNames({ locale, weekStartsOn: 1, format: 'narrow' }).map((label, index) => ({
+    id: `day-${index}`,
     label,
   }));
 
@@ -119,7 +120,7 @@ export const Hero = async () => {
             </div>
             <div className='px-[18px] pt-[18px] pb-4 bg-[var(--accent)] text-[var(--color-brand-ink)] border-[4px] border-[var(--frame)] rounded-[10px]'>
               <div className='font-mono text-[12px] uppercase tracking-[0.1em] mb-1' suppressHydrationWarning>
-                {t('hero.mockupLabel', { year: new Date().getFullYear() })}
+                {t('hero.mockupLabel', { year })}
               </div>
               <div className='font-display font-extrabold text-[56px] leading-none tracking-[-0.03em] flex items-baseline gap-2.5'>
                 47

--- a/src/ui/modules/pages/homepage/sections/Testimonials.tsx
+++ b/src/ui/modules/pages/homepage/sections/Testimonials.tsx
@@ -1,5 +1,7 @@
 import { Badge } from '@ui/modules/core/primitives/Badge';
 import { cn } from '@ui/utils/cn';
+import { cacheLife } from 'next/cache';
+import type { Locale } from 'next-intl';
 import { getTranslations } from 'next-intl/server';
 import { brutCard } from './shared';
 
@@ -16,8 +18,14 @@ type TestimonialKey = 'martaR' | 'diegoA' | 'saraV' | 'carlosM' | 'lauraT' | 'th
 
 const TESTIMONIAL_KEYS: TestimonialKey[] = ['martaR', 'diegoA', 'saraV', 'carlosM', 'lauraT', 'thomasK'];
 
-export const Testimonials = async () => {
-  const t = await getTranslations('homepage');
+interface TestimonialsProps {
+  locale: Locale;
+}
+
+export const Testimonials = async ({ locale }: TestimonialsProps) => {
+  'use cache';
+  cacheLife('days');
+  const t = await getTranslations({ locale, namespace: 'homepage' });
 
   const shuffledKeys = TESTIMONIAL_KEYS.toSorted(() => Math.random() - 0.5);
 

--- a/src/ui/modules/pages/not-found/HtmlLangSync.tsx
+++ b/src/ui/modules/pages/not-found/HtmlLangSync.tsx
@@ -1,0 +1,12 @@
+import type { Locale } from 'next-intl';
+
+interface HtmlLangSyncProps {
+  locale: Locale;
+}
+
+export const HtmlLangSync = ({ locale }: HtmlLangSyncProps) => (
+  <script
+    // biome-ignore lint/security/noDangerouslySetInnerHtml: syncs <html lang> as soon as the streamed chunk parses, without waiting for hydration
+    dangerouslySetInnerHTML={{ __html: `document.documentElement.lang=${JSON.stringify(locale)};` }}
+  />
+);

--- a/src/ui/modules/pages/planner/calendar/Calendar.tsx
+++ b/src/ui/modules/pages/planner/calendar/Calendar.tsx
@@ -21,7 +21,7 @@ import { cn } from '@ui/utils/cn';
 import { LockIcon } from 'lucide-react';
 import type { Locale } from 'next-intl';
 import { useTranslations } from 'next-intl';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import { getCalendarDays, getWeekdayNames } from '../utils/helpers';
 import {
@@ -126,6 +126,11 @@ export function Calendar({
   const premiumKey = usePremiumStore((state) => state.premiumKey);
   const [currentMonth, setCurrentMonth] = useState(initialMonth ?? new Date());
   const [hoverDate, setHoverDate] = useState<Date | undefined>();
+  const [today, setToday] = useState<Date | null>(null);
+
+  useEffect(() => {
+    setToday(new Date());
+  }, []);
   const [rangeSelection, setRangeSelection] = useState<RangeState>(() => {
     if (mode === CalendarSelectionMode.RANGE && isFromToObject(selected)) {
       return {
@@ -154,7 +159,7 @@ export function Calendar({
     const holidayFn = isHoliday(holidays);
     const customFn = isCustomFn(holidays);
     const bankHolidayFn = isBankHolidayFn(holidays);
-    const isPastFn = isPast(allowPastDays);
+    const isPastFn = isPast(allowPastDays, today);
     const isSuggestionFn = isSuggestion(currentSelection, removedSuggestedDays);
     const isAlternativeFn = isAlternative({ alternatives, suggestion, previewAlternativeIndex, currentSelection });
     const isManuallySelectedFn = isManuallySelected(manuallySelectedDays);
@@ -166,7 +171,7 @@ export function Calendar({
       holiday: holidayFn,
       custom: customFn,
       bankHoliday: bankHolidayFn,
-      today: isToday,
+      today: isToday(today),
       suggested: isSuggestionFn,
       alternative: isAlternativeFn,
       disabled: isPastFn,
@@ -200,6 +205,7 @@ export function Calendar({
     hoverDate,
     manuallySelectedDays,
     removedSuggestedDays,
+    today,
   ]);
 
   const weekdayNames = useMemo(() => getWeekdayNames({ locale, weekStartsOn }), [locale, weekStartsOn]);
@@ -491,6 +497,7 @@ export function Calendar({
             disabled: isDisabled,
             showOutsideDays,
             allowPastDays,
+            today,
             modifiers,
           });
 

--- a/src/ui/modules/pages/planner/calendar/utils/helpers.ts
+++ b/src/ui/modules/pages/planner/calendar/utils/helpers.ts
@@ -8,6 +8,7 @@ interface GetDayClassNamesParams {
   disabled?: boolean;
   showOutsideDays: boolean;
   allowPastDays?: boolean;
+  today: Date | null;
   modifiers: Record<string, (date: Date) => boolean>;
 }
 
@@ -43,13 +44,13 @@ export const getDayClassNames = ({
   disabled = false,
   showOutsideDays,
   allowPastDays = true,
+  today,
   modifiers,
 }: GetDayClassNamesParams) => {
   const classes: string[] = [];
   const isOutsideMonth = !isSameMonth(date, month);
   const isSelected = selectedDates.some((d) => isSameDay(d, date));
-  const today = startOfDay(new Date());
-  const isPastDay = isBefore(startOfDay(date), today);
+  const isPastDay = today ? isBefore(startOfDay(date), startOfDay(today)) : false;
   const shouldShowAsPast = isPastDay && !allowPastDays;
 
   classes.push(

--- a/src/ui/modules/pages/planner/utils/modifiers.ts
+++ b/src/ui/modules/pages/planner/utils/modifiers.ts
@@ -1,5 +1,5 @@
 import { type HolidayDTO, HolidayVariant } from '@application/dto/holiday/types';
-import { isBefore, isSameDay, startOfToday } from '@application/shared/utils/dates';
+import { isBefore, isSameDay, startOfDay } from '@application/shared/utils/dates';
 import type { HolidaysState } from '@application/stores/holidays';
 import type { Suggestion } from '@domain/calendar/types';
 import type { FromTo } from '../calendar/Calendar';
@@ -7,17 +7,17 @@ import type { FromTo } from '../calendar/Calendar';
 export const isHoliday = (holidays: HolidaysState['holidays']) => (date: Date) =>
   holidays.some((holiday) => isSameDay(date, holiday.date));
 
-export const isPast = (allowPastDays: boolean) => {
-  if (allowPastDays) {
+export const isPast = (allowPastDays: boolean, today: Date | null) => {
+  if (allowPastDays || !today) {
     return () => false;
   }
 
-  const today = startOfToday();
+  const todayStart = startOfDay(today);
 
-  return (date: Date) => isBefore(date, today);
+  return (date: Date) => isBefore(date, todayStart);
 };
 
-export const isToday = (date: Date) => isSameDay(date, new Date());
+export const isToday = (today: Date | null) => (date: Date) => (today ? isSameDay(date, today) : false);
 
 export const isSuggestion = (currentSelection: Suggestion | null, removedSuggestedDays: Date[] = []) => {
   return (date: Date) => {

--- a/src/ui/modules/shared/footer/Footer.tsx
+++ b/src/ui/modules/shared/footer/Footer.tsx
@@ -1,4 +1,5 @@
 import { Link } from '@application/i18n/navigation';
+import { getCurrentYear } from '@ui/utils/getCurrentYear';
 import Image from 'next/image';
 import { getTranslations } from 'next-intl/server';
 import { version } from '../../../../../package.json';
@@ -7,7 +8,7 @@ import { CookieButton } from './components/CookieButton';
 import { DevFooter } from './components/DevFooter';
 
 export const Footer = async () => {
-  const t = await getTranslations('footer');
+  const [t, year] = await Promise.all([getTranslations('footer'), getCurrentYear()]);
 
   return (
     <footer className='w-full bg-background border-t-[3px] border-[var(--frame)] relative z-10'>
@@ -73,7 +74,7 @@ export const Footer = async () => {
 
         <div className='px-7 py-3 border-t-[2px] border-dashed border-[var(--frame)]/18 flex justify-center'>
           <span className='font-mono text-[11px] text-muted-foreground text-center' suppressHydrationWarning>
-            {t('copyright', { year: new Date().getFullYear() })}
+            {t('copyright', { year })}
           </span>
         </div>
       </div>

--- a/src/ui/modules/shared/footer/components/DevFooter.tsx
+++ b/src/ui/modules/shared/footer/components/DevFooter.tsx
@@ -44,10 +44,11 @@ const getRandomEmoji = () => EMOJIS[Math.floor(Math.random() * EMOJIS.length)];
 
 export const DevFooter = () => {
   const t = useTranslations('devFooter');
-  const [currentEmoji, setCurrentEmoji] = useState(getRandomEmoji);
+  const [currentEmoji, setCurrentEmoji] = useState(EMOJIS[0]);
   const intervalRef = useRef<NodeJS.Timeout>(null);
 
   useEffect(() => {
+    setCurrentEmoji(getRandomEmoji());
     intervalRef.current = setInterval(() => {
       setCurrentEmoji(getRandomEmoji());
     }, 3000);

--- a/src/ui/modules/shared/seo/JsonLd.tsx
+++ b/src/ui/modules/shared/seo/JsonLd.tsx
@@ -1,5 +1,5 @@
 import { LOCALES } from '@infrastructure/i18n/locales';
-import { getCloudflareContext } from '@opennextjs/cloudflare';
+import { getPublicEnv } from '@infrastructure/services/env/getPublicEnv';
 import type { Locale } from 'next-intl';
 import { getTranslations } from 'next-intl/server';
 
@@ -8,13 +8,11 @@ interface JsonLdProps {
 }
 
 export async function JsonLd({ locale }: JsonLdProps) {
-  const [{ env }, t, tFaq] = await Promise.all([
-    getCloudflareContext({ async: true }),
+  const [{ siteUrl: baseUrl }, t, tFaq] = await Promise.all([
+    getPublicEnv(),
     getTranslations({ locale, namespace: 'metadata' }),
     getTranslations({ locale, namespace: 'faq' }),
   ]);
-
-  const baseUrl = env.NEXT_PUBLIC_SITE_URL;
 
   const webApplicationSchema = {
     '@context': 'https://schema.org',

--- a/src/ui/modules/sidebar/AppSidebar.tsx
+++ b/src/ui/modules/sidebar/AppSidebar.tsx
@@ -1,5 +1,4 @@
 import {
-  SIDEBAR_COOKIE_NAME,
   Sidebar,
   SidebarContent,
   SidebarGroup,
@@ -16,9 +15,9 @@ import { ChevronDown } from '@ui/modules/core/animate/icons/ChevronDown';
 import { AnimateIcon } from '@ui/modules/core/animate/icons/Icon';
 import { Settings } from '@ui/modules/core/animate/icons/Settings';
 import { Logo } from '@ui/modules/shared/Logo';
+import { getCurrentYear } from '@ui/utils/getCurrentYear';
 import { Calculator } from 'lucide-react';
 import dynamic from 'next/dynamic';
-import { cookies } from 'next/headers';
 import type { Locale } from 'next-intl';
 import { getTranslations } from 'next-intl/server';
 import { type ReactNode, Suspense } from 'react';
@@ -48,11 +47,10 @@ interface AppSidebarProps {
 }
 
 export const AppSidebar = async ({ locale, children }: AppSidebarProps) => {
-  const [t, cookieStore] = await Promise.all([getTranslations('sidebar'), cookies()]);
-  const sidebarOpen = cookieStore.get(SIDEBAR_COOKIE_NAME)?.value !== 'false';
+  const [t, currentYear] = await Promise.all([getTranslations('sidebar'), getCurrentYear()]);
 
   return (
-    <SidebarProvider defaultOpen={sidebarOpen}>
+    <SidebarProvider>
       <Sidebar collapsible='icon' variant='inset'>
         <SidebarHeader className='group-data-[collapsible=icon]:p-0 mb-2.5'>
           <SidebarMenu>
@@ -97,7 +95,7 @@ export const AppSidebar = async ({ locale, children }: AppSidebarProps) => {
                           <Countries locale={locale} />
                         </Suspense>
                         <Regions />
-                        <Years />
+                        <Years currentYear={currentYear} />
                       </div>
                     </div>
 
@@ -171,7 +169,7 @@ export const AppSidebar = async ({ locale, children }: AppSidebarProps) => {
                 >
                   <div className='px-1 pt-2 pb-1 space-y-[18px]'>
                     <div className={STEP_CARD_CLASS}>
-                      <PtoCalculator />
+                      <PtoCalculator currentYear={currentYear} />
                     </div>
                     <div className={STEP_CARD_CLASS}>
                       <PtoSalaryCalculator />

--- a/src/ui/modules/sidebar/components/PtoCalculator.tsx
+++ b/src/ui/modules/sidebar/components/PtoCalculator.tsx
@@ -19,7 +19,11 @@ interface MonthOption {
   label: string;
 }
 
-export const PtoCalculator = () => {
+interface PtoCalculatorProps {
+  currentYear: number;
+}
+
+export const PtoCalculator = ({ currentYear }: PtoCalculatorProps) => {
   const locale = useLocale();
   const t = useTranslations('ptoCalculator');
   const [daysPerMonth, setDaysPerMonth] = useState<number>(2.5);
@@ -38,7 +42,7 @@ export const PtoCalculator = () => {
     const monthNames = getMonthNames({
       locale,
       monthCount: 12,
-      startYear: new Date().getFullYear(),
+      startYear: currentYear,
       monthOutputFormat: 'long',
     });
 
@@ -46,7 +50,7 @@ export const PtoCalculator = () => {
       value: (index + 1).toString(),
       label: monthName,
     }));
-  }, [locale]);
+  }, [locale, currentYear]);
 
   const handleCalculate = () => {
     const monthNumber = Number(selectedMonth);

--- a/src/ui/modules/sidebar/components/Years.tsx
+++ b/src/ui/modules/sidebar/components/Years.tsx
@@ -15,7 +15,11 @@ import { useShallow } from 'zustand/react/shallow';
 
 const MAX_YEARS = 10;
 
-export const Years = () => {
+interface YearsProps {
+  currentYear: number;
+}
+
+export const Years = ({ currentYear }: YearsProps) => {
   const t = useTranslations('sidebar.years');
   const [open, setOpen] = useState(false);
   const { year, setYear } = useFiltersStore(
@@ -25,7 +29,7 @@ export const Years = () => {
     }))
   );
 
-  const years = Array.from({ length: MAX_YEARS }, (_, index) => new Date().getFullYear() - MAX_YEARS / 2 + index);
+  const years = Array.from({ length: MAX_YEARS }, (_, index) => currentYear - MAX_YEARS / 2 + index);
 
   return (
     <div className='space-y-2 w-full' data-tutorial='year'>

--- a/src/ui/utils/getCurrentYear.ts
+++ b/src/ui/utils/getCurrentYear.ts
@@ -1,0 +1,7 @@
+import { cacheLife } from 'next/cache';
+
+export async function getCurrentYear() {
+  'use cache';
+  cacheLife('days');
+  return new Date().getFullYear();
+}

--- a/src/ui/utils/getLastUpdatedDate.ts
+++ b/src/ui/utils/getLastUpdatedDate.ts
@@ -1,0 +1,11 @@
+import type { Locale } from 'next-intl';
+
+const LAST_UPDATED = new Date(2026, 2, 31);
+
+export function getLastUpdatedDate(locale: Locale) {
+  return LAST_UPDATED.toLocaleDateString(locale, {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
+}

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,4 +1,9 @@
 import { cleanup } from '@testing-library/react';
-import { afterEach } from 'vitest';
+import { afterEach, vi } from 'vitest';
+
+vi.mock('next/cache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('next/cache')>();
+  return { ...actual, cacheLife: vi.fn(), cacheTag: vi.fn() };
+});
 
 afterEach(cleanup);


### PR DESCRIPTION
## Description

Adopts the Next.js 16 Cache Components model (`cacheComponents: true`): every route is dynamic by default, caching is an explicit opt-in via `'use cache'`, and Partial Prerendering (static shell + streamed holes) comes built in.

The key design goal is that `/planner` ships a **fully prerendered static shell with the real UI** (sidebar, titles, the 13 calendar grids, footer — ~900KB of real HTML per locale) instead of a skeleton. Navigation from the homepage gets the complete page from the `<Link>` prefetch, and hard loads paint real content on first byte. This supersedes #329, which wrapped the entire planner layout in a route-level `<Suspense fallback={<PlannerSkeleton/>}>` — that collapsed the static shell to a skeleton and made every navigation stream the whole page, which is why `/planner` felt much slower there.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [x] 🔧 Configuration change
- [x] ⚡ Performance improvement
- [ ] ✅ Test update

## Related Issue

Supersedes #329

## Changes Made

- **`next.config.ts`**: `cacheComponents: true` (top-level flag, includes PPR). One line — rollback is a one-line revert.
- **Planner static shell (the perf fix)**:
  - `AppSidebar` no longer reads `cookies()` (the only per-user server read in the planner tree). The sidebar open/closed preference is restored client-side by `SidebarProvider` reading `document.cookie` after mount — users with a collapsed preference see a one-time expand→collapse correction at hydration; default-open users see none.
  - No route-level Suspense, no `PlannerSkeleton`. Nothing dynamic is left in the tree, so the whole route prerenders.
- **Prerender-safe time/randomness** (build errors under the cacheComponents prerender validator):
  - New cached helpers: `getPublicEnv()` (`'use cache'`, replaces raw `getCloudflareContext` in all `generateMetadata`, JsonLd and the legal pages — its first call initializes the wrangler proxy with `new Date()`, which the validator rejects outside cache scopes) and `getCurrentYear()` (Footer copyright, Hero mockup label, `Years`/`PtoCalculator` sidebar components now take the year as a prop instead of calling `new Date()` in render).
  - `Calendar`: "today" is now `null` during prerender and set in a mount effect — past-day/today styling appears after hydration (`isPast`/`isToday`/`getDayClassNames` take it as a param). The prerendered grids are date-agnostic and cacheable.
  - Legal pages: "last updated" is a fixed date (March 31, 2026) formatted per locale (`getLastUpdatedDate`), replacing the rolling `startOfToday() - 7d` computation.
  - `Testimonials`: component-level `'use cache'` + `cacheLife('days')` with explicit locale — the shuffle now runs at cache-fill instead of per prerender.
  - `Hero` day-header keys use positional ids instead of `crypto.randomUUID()`; `DevFooter` seeds its emoji deterministically and randomizes on mount (also fixes a latent hydration mismatch).
- **`patches/boneyard-js.patch`**: `<Skeleton>` generated its per-instance uid with `Math.random()` during render, which the prerender validator rejects. Patched to React's `useId()` (deterministic and SSR-safe). Should be upstreamed to boneyard-js and the patch dropped afterwards.
- **`force-dynamic` removals** (`.well-known`, `api/markdown`, `payment/confirmation`): the `dynamic` segment config is a build error under cacheComponents; route handlers stay dynamic by default with zero behavior change.
- **`payment/confirmation`**: new `loading.tsx` boundary (the page reads `searchParams` and hits Stripe, so it streams below the boundary).
- **`global-not-found`**: locale detection (`headers()`/`cookies()`) moved inside a Suspense boundary as required; the static shell uses the default locale and `HtmlLangSync` fixes `<html lang>` as soon as the streamed chunk parses.
- **`vitest.setup.ts`**: no-op `cacheLife`/`cacheTag` mocks (they throw outside the Next runtime).

### Deliberately NOT included (vs #329)

- `partialPrefetching`: requires Next 16.3, which only exists as `16.3.0-preview.5`. Verified empirically: `next build` passes on the preview, but `opennextjs-cloudflare build` fails, and @opennextjs/cloudflare explicitly doesn't support 16.3 yet (opennextjs-cloudflare#1300). Follow-up PR once 16.3 is stable and the adapter supports it.
- Middleware payment redirect + BetterStack-in-middleware, `instrumentation.ts`, BetterStack no-throw client, `robots`/`sitemap` env swaps (metadata route handlers are exempt from prerender validation), page-level `'use cache'` on legal pages and its locale plumbing (`RichLink`/`LegalLayout`/`getPathname`) — all orthogonal to the flag or made unnecessary by the narrower design.

## Testing

- [x] Existing unit tests pass (`pnpm test:ut`) — 1272 tests, 142 files
- [ ] Added new tests for changes
- [ ] Manually tested in browser
- [x] Build passes (`pnpm build`) — zero prerender errors; route table shows `◐` for all locale routes with the planner shell containing the real markup (verified `data-slot="sidebar-wrapper"`, 13 `role="grid"` calendars and the footer in `.next/server/app/en/planner.html`, no skeleton)

> Note: `opennextjs-cloudflare build` currently fails on Windows on `main` too (dangling pnpm junctions, esbuild "Access is denied" — the CLI itself warns OpenNext is not fully compatible with Windows), so the Cloudflare validation gate for this PR is the CI preview deploy.

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format`)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Known risks of `cacheComponents` on Cloudflare Workers to watch on the preview deploy before merging:

- **CacheSignal/IoContext timer bug** (better-auth#10103): on workerd, Next's CacheSignal can register timers in one request's IoContext and blow up a later request with "Cannot perform I/O on behalf of a different request" (Error 1101), typically once cookies make document requests dynamic. Repro on preview: several sequential document requests in one session with cookies set, plus the dynamic `payment/confirmation` route; watch `wrangler tail` for 1101s.
- **opennextjs-cloudflare#1225** ("Connection closed" / blank static shell) and **#1130** (prod-only `SyntaxError`) are still open. Adapter 1.20.1 already includes the PPR streaming fix from #1115.
- `enableCacheInterception` must stay off in `open-next.config.ts` (incompatible with PPR) — current config is already correct.

If anything misbehaves, reverting the `cacheComponents: true` line restores today's behavior; every other change is flag-agnostic-safe.

---

## GIF (mandatory)

<div align="center">

![instant](https://media.giphy.com/media/5wWf7GR2nhgamhRnEuA/giphy.gif)

_Thanks for contributing!_ ✨

</div>