### PR TITLE
fix: mobile tap support for tooltips and unblock content under the cookie banner

### DIFF
--- a/src/ui/modules/core/animate/components/FeatureList.tsx
+++ b/src/ui/modules/core/animate/components/FeatureList.tsx
@@ -52,9 +52,6 @@ const viewAllTextVariants = {
 export function FeatureList({ features, categoryLabel, detailedViewLabel }: Readonly<FeatureListProps>) {
   const [expanded, setExpanded] = useState(false);
 
-  // whileTap only lasts while the finger is down, so touch devices (no hover)
-  // need the expansion to persist: tap toggles it. Hover devices keep the
-  // hover-driven behavior untouched.
   const handleClick = () => {
     if (globalThis.matchMedia?.('(hover: none)').matches) {
       setExpanded((value) => !value);

--- a/src/ui/modules/core/animate/components/FeatureList.tsx
+++ b/src/ui/modules/core/animate/components/FeatureList.tsx
@@ -2,6 +2,7 @@
 
 import { Badge } from '@ui/modules/core/primitives/Badge';
 import { m, type Transition } from 'motion/react';
+import { useState } from 'react';
 
 interface RoadmapFeature {
   id: string;
@@ -49,12 +50,25 @@ const viewAllTextVariants = {
 };
 
 export function FeatureList({ features, categoryLabel, detailedViewLabel }: Readonly<FeatureListProps>) {
+  const [expanded, setExpanded] = useState(false);
+
+  // whileTap only lasts while the finger is down, so touch devices (no hover)
+  // need the expansion to persist: tap toggles it. Hover devices keep the
+  // hover-driven behavior untouched.
+  const handleClick = () => {
+    if (globalThis.matchMedia?.('(hover: none)').matches) {
+      setExpanded((value) => !value);
+    }
+  };
+
   return (
     <m.div
       className='bg-card border-[3px] border-(--frame) rounded-[14px] p-4 w-full space-y-3 shadow-(--shadow-brutal-md)'
       initial='collapsed'
+      animate={expanded ? 'expanded' : 'collapsed'}
       whileHover='expanded'
       whileTap='expanded'
+      onClick={handleClick}
     >
       <div>
         {features.map((feature, i) => (

--- a/src/ui/modules/core/animate/components/FeatureList.tsx
+++ b/src/ui/modules/core/animate/components/FeatureList.tsx
@@ -2,7 +2,6 @@
 
 import { Badge } from '@ui/modules/core/primitives/Badge';
 import { m, type Transition } from 'motion/react';
-import { useState } from 'react';
 
 interface RoadmapFeature {
   id: string;
@@ -50,22 +49,12 @@ const viewAllTextVariants = {
 };
 
 export function FeatureList({ features, categoryLabel, detailedViewLabel }: Readonly<FeatureListProps>) {
-  const [expanded, setExpanded] = useState(false);
-
-  const handleClick = () => {
-    if (globalThis.matchMedia?.('(hover: none)').matches) {
-      setExpanded((value) => !value);
-    }
-  };
-
   return (
     <m.div
       className='bg-card border-[3px] border-(--frame) rounded-[14px] p-4 w-full space-y-3 shadow-(--shadow-brutal-md)'
       initial='collapsed'
-      animate={expanded ? 'expanded' : 'collapsed'}
       whileHover='expanded'
       whileTap='expanded'
-      onClick={handleClick}
     >
       <div>
         {features.map((feature, i) => (

--- a/src/ui/modules/core/animate/primitives/base/Tooltip.test.tsx
+++ b/src/ui/modules/core/animate/primitives/base/Tooltip.test.tsx
@@ -1,0 +1,115 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ComponentProps, ReactElement, ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+type MotionDivProps = ComponentProps<'div'> & {
+  initial?: unknown;
+  animate?: unknown;
+  exit?: unknown;
+  transition?: unknown;
+};
+
+vi.mock('motion/react', async () => {
+  const { createElement, Fragment } = await import('react');
+  return {
+    m: {
+      div: ({ children, initial: _i, animate: _a, exit: _e, transition: _t, style, ...props }: MotionDivProps) =>
+        createElement('div', { style, ...props }, children),
+    },
+    AnimatePresence: ({ children }: { children?: ReactNode }) => createElement(Fragment, null, children),
+    useMotionValue: () => ({ set: vi.fn() }),
+    useSpring: () => ({ set: vi.fn() }),
+  };
+});
+
+vi.mock('@base-ui/react/tooltip', async () => {
+  const { createElement, cloneElement, Fragment } = await import('react');
+  type RenderableProps = ComponentProps<'div'> & { render?: ReactElement; keepMounted?: boolean };
+  const renderable =
+    (slot: string, tag = 'div') =>
+    ({ render: renderProp, children, keepMounted: _k, ...props }: RenderableProps) =>
+      renderProp
+        ? cloneElement(
+            renderProp,
+            props as Record<string, unknown>,
+            children ?? (renderProp.props as { children?: ReactNode }).children
+          )
+        : createElement(tag, { 'data-slot': slot, ...props }, children);
+  return {
+    Tooltip: {
+      Provider: ({ children }: { children?: ReactNode; delay?: number }) => createElement(Fragment, null, children),
+      Root: ({ children }: { children?: ReactNode; open?: boolean; onOpenChange?: unknown }) =>
+        createElement(Fragment, null, children),
+      Trigger: renderable('base-trigger', 'button'),
+      Portal: ({ children }: { children?: ReactNode; keepMounted?: boolean }) =>
+        createElement(Fragment, null, children),
+      Positioner: renderable('base-positioner'),
+      Popup: renderable('base-popup'),
+      Arrow: renderable('base-arrow'),
+    },
+  };
+});
+
+import { Tooltip, TooltipPopup, TooltipPortal, TooltipPositioner, TooltipTrigger } from './Tooltip';
+
+const stubHoverCapability = (canHover: boolean) => {
+  vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: !canHover }));
+};
+
+const renderTooltip = () =>
+  render(
+    <Tooltip>
+      <TooltipTrigger>info</TooltipTrigger>
+      <TooltipPortal>
+        <TooltipPositioner>
+          <TooltipPopup>tip content</TooltipPopup>
+        </TooltipPositioner>
+      </TooltipPortal>
+    </Tooltip>
+  );
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('Tooltip tap support on touch devices', () => {
+  it('opens on trigger click when the device cannot hover', () => {
+    stubHoverCapability(false);
+    renderTooltip();
+    expect(screen.queryByText('tip content')).toBeNull();
+
+    fireEvent.click(screen.getByText('info'));
+    expect(screen.queryByText('tip content')).not.toBeNull();
+  });
+
+  it('toggles closed on a second trigger click', () => {
+    stubHoverCapability(false);
+    renderTooltip();
+    const trigger = screen.getByText('info');
+
+    fireEvent.click(trigger);
+    expect(screen.queryByText('tip content')).not.toBeNull();
+
+    fireEvent.click(trigger);
+    expect(screen.queryByText('tip content')).toBeNull();
+  });
+
+  it('dismisses on pointerdown outside the trigger', () => {
+    stubHoverCapability(false);
+    renderTooltip();
+
+    fireEvent.click(screen.getByText('info'));
+    expect(screen.queryByText('tip content')).not.toBeNull();
+
+    fireEvent.pointerDown(document.body);
+    expect(screen.queryByText('tip content')).toBeNull();
+  });
+
+  it('does not toggle on click when the device can hover', () => {
+    stubHoverCapability(true);
+    renderTooltip();
+
+    fireEvent.click(screen.getByText('info'));
+    expect(screen.queryByText('tip content')).toBeNull();
+  });
+});

--- a/src/ui/modules/core/animate/primitives/base/Tooltip.test.tsx
+++ b/src/ui/modules/core/animate/primitives/base/Tooltip.test.tsx
@@ -1,6 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import type { ComponentProps, ReactElement, ReactNode } from 'react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 type MotionDivProps = ComponentProps<'div'> & {
   initial?: unknown;
@@ -22,11 +22,16 @@ vi.mock('motion/react', async () => {
   };
 });
 
-vi.mock('@base-ui/react/tooltip', async () => {
+vi.mock('@base-ui/react/popover', async () => {
   const { createElement, cloneElement, Fragment } = await import('react');
+  type TriggerProps = ComponentProps<'button'> & {
+    render?: ReactElement;
+    openOnHover?: boolean;
+    delay?: number;
+  };
   type RenderableProps = ComponentProps<'div'> & { render?: ReactElement; keepMounted?: boolean };
   const renderable =
-    (slot: string, tag = 'div') =>
+    (slot: string) =>
     ({ render: renderProp, children, keepMounted: _k, ...props }: RenderableProps) =>
       renderProp
         ? cloneElement(
@@ -34,13 +39,17 @@ vi.mock('@base-ui/react/tooltip', async () => {
             props as Record<string, unknown>,
             children ?? (renderProp.props as { children?: ReactNode }).children
           )
-        : createElement(tag, { 'data-slot': slot, ...props }, children);
+        : createElement('div', { 'data-slot': slot, ...props }, children);
   return {
-    Tooltip: {
-      Provider: ({ children }: { children?: ReactNode; delay?: number }) => createElement(Fragment, null, children),
+    Popover: {
       Root: ({ children }: { children?: ReactNode; open?: boolean; onOpenChange?: unknown }) =>
         createElement(Fragment, null, children),
-      Trigger: renderable('base-trigger', 'button'),
+      Trigger: ({ children, openOnHover, delay, ...props }: TriggerProps) =>
+        createElement(
+          'button',
+          { 'data-open-on-hover': String(openOnHover), 'data-delay': String(delay), ...props },
+          children
+        ),
       Portal: ({ children }: { children?: ReactNode; keepMounted?: boolean }) =>
         createElement(Fragment, null, children),
       Positioner: renderable('base-positioner'),
@@ -50,66 +59,45 @@ vi.mock('@base-ui/react/tooltip', async () => {
   };
 });
 
-import { Tooltip, TooltipPopup, TooltipPortal, TooltipPositioner, TooltipTrigger } from './Tooltip';
+import { Tooltip, TooltipPopup, TooltipPortal, TooltipPositioner, TooltipProvider, TooltipTrigger } from './Tooltip';
 
-const stubHoverCapability = (canHover: boolean) => {
-  vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: !canHover }));
-};
-
-const renderTooltip = () =>
+const renderTooltip = (ui?: { delay?: number; triggerDelay?: number; defaultOpen?: boolean }) =>
   render(
-    <Tooltip>
-      <TooltipTrigger>info</TooltipTrigger>
-      <TooltipPortal>
-        <TooltipPositioner>
-          <TooltipPopup>tip content</TooltipPopup>
-        </TooltipPositioner>
-      </TooltipPortal>
-    </Tooltip>
+    <TooltipProvider delay={ui?.delay}>
+      <Tooltip defaultOpen={ui?.defaultOpen}>
+        <TooltipTrigger delay={ui?.triggerDelay}>info</TooltipTrigger>
+        <TooltipPortal>
+          <TooltipPositioner>
+            <TooltipPopup>tip content</TooltipPopup>
+          </TooltipPositioner>
+        </TooltipPortal>
+      </Tooltip>
+    </TooltipProvider>
   );
 
-afterEach(() => {
-  vi.unstubAllGlobals();
-});
-
-describe('Tooltip tap support on touch devices', () => {
-  it('opens on trigger click when the device cannot hover', () => {
-    stubHoverCapability(false);
+describe('Tooltip (popover-based, touch-capable)', () => {
+  it('enables openOnHover on the trigger so hover and tap both open it', () => {
     renderTooltip();
-    expect(screen.queryByText('tip content')).toBeNull();
-
-    fireEvent.click(screen.getByText('info'));
-    expect(screen.queryByText('tip content')).not.toBeNull();
+    expect(screen.getByText('info').getAttribute('data-open-on-hover')).toBe('true');
   });
 
-  it('toggles closed on a second trigger click', () => {
-    stubHoverCapability(false);
+  it('threads the provider delay into the trigger', () => {
+    renderTooltip({ delay: 200 });
+    expect(screen.getByText('info').getAttribute('data-delay')).toBe('200');
+  });
+
+  it('lets an explicit trigger delay override the provider delay', () => {
+    renderTooltip({ delay: 200, triggerDelay: 50 });
+    expect(screen.getByText('info').getAttribute('data-delay')).toBe('50');
+  });
+
+  it('renders the popup only while open', () => {
     renderTooltip();
-    const trigger = screen.getByText('info');
-
-    fireEvent.click(trigger);
-    expect(screen.queryByText('tip content')).not.toBeNull();
-
-    fireEvent.click(trigger);
     expect(screen.queryByText('tip content')).toBeNull();
   });
 
-  it('dismisses on pointerdown outside the trigger', () => {
-    stubHoverCapability(false);
-    renderTooltip();
-
-    fireEvent.click(screen.getByText('info'));
+  it('renders the popup when open', () => {
+    renderTooltip({ defaultOpen: true });
     expect(screen.queryByText('tip content')).not.toBeNull();
-
-    fireEvent.pointerDown(document.body);
-    expect(screen.queryByText('tip content')).toBeNull();
-  });
-
-  it('does not toggle on click when the device can hover', () => {
-    stubHoverCapability(true);
-    renderTooltip();
-
-    fireEvent.click(screen.getByText('info'));
-    expect(screen.queryByText('tip content')).toBeNull();
   });
 });

--- a/src/ui/modules/core/animate/primitives/base/Tooltip.tsx
+++ b/src/ui/modules/core/animate/primitives/base/Tooltip.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Tooltip as TooltipPrimitive } from '@base-ui/react/tooltip';
+import { Popover as PopoverPrimitive } from '@base-ui/react/popover';
 import { useControlledState } from '@ui/hooks/useControlledState';
 import { getStrictContext } from '@ui/utils/context';
 import {
@@ -12,27 +12,25 @@ import {
   useMotionValue,
   useSpring,
 } from 'motion/react';
-import { type ComponentProps, isValidElement, type RefObject, useCallback, useEffect, useMemo, useRef } from 'react';
+import { type ComponentProps, createContext, isValidElement, type ReactNode, use, useMemo } from 'react';
 
 type TooltipContextType = {
   isOpen: boolean;
-  setIsOpen: TooltipProps['onOpenChange'];
-  /** Programmatic open/close (tap-to-toggle, outside dismiss) without Base UI event details. */
-  setOpen: (open: boolean) => void;
   x: MotionValue<number>;
   y: MotionValue<number>;
   followCursor?: boolean | 'x' | 'y';
   followCursorSpringOptions?: SpringOptions;
-  triggerRef: RefObject<HTMLElement | null>;
 };
 const [LocalTooltipProvider, useTooltip] = getStrictContext<TooltipContextType>('TooltipContext');
 
-type TooltipProviderProps = ComponentProps<typeof TooltipPrimitive.Provider>;
-function TooltipProvider(props: TooltipProviderProps) {
-  return <TooltipPrimitive.Provider data-slot='tooltip-provider' {...props} />;
+const TooltipDelayContext = createContext(0);
+
+type TooltipProviderProps = { delay?: number; children?: ReactNode };
+function TooltipProvider({ delay = 0, children }: TooltipProviderProps) {
+  return <TooltipDelayContext.Provider value={delay}>{children}</TooltipDelayContext.Provider>;
 }
 
-type TooltipProps = ComponentProps<typeof TooltipPrimitive.Root> & {
+type TooltipProps = ComponentProps<typeof PopoverPrimitive.Root> & {
   followCursor?: boolean | 'x' | 'y';
   followCursorSpringOptions?: SpringOptions;
 };
@@ -48,97 +46,68 @@ function Tooltip({
   });
   const x = useMotionValue(0);
   const y = useMotionValue(0);
-  const triggerRef = useRef<HTMLElement | null>(null);
-
-  const setOpen = useCallback(
-    (open: boolean) => {
-      (setIsOpen as unknown as (open: boolean, eventDetails?: unknown) => void)?.(open, undefined);
-    },
-    [setIsOpen]
-  );
-
-  // Touch devices open the tooltip by tapping the trigger (see TooltipTrigger),
-  // and nothing hover-based ever closes it — dismiss on the next press outside.
-  useEffect(() => {
-    if (!isOpen) return;
-    const handlePointerDown = (event: PointerEvent) => {
-      if (triggerRef.current?.contains(event.target as Node)) return;
-      setOpen(false);
-    };
-    document.addEventListener('pointerdown', handlePointerDown, true);
-    return () => document.removeEventListener('pointerdown', handlePointerDown, true);
-  }, [isOpen, setOpen]);
-
   const tooltipContextValue = useMemo(
-    () => ({ isOpen, setIsOpen, setOpen, x, y, followCursor, followCursorSpringOptions, triggerRef }),
-    [isOpen, setIsOpen, setOpen, x, y, followCursor, followCursorSpringOptions]
+    () => ({ isOpen, x, y, followCursor, followCursorSpringOptions }),
+    [isOpen, x, y, followCursor, followCursorSpringOptions]
   );
   return (
     <LocalTooltipProvider value={tooltipContextValue}>
-      {/* Controlled: the tap-to-open path (touch devices) must drive Base UI's
-          internal state too, or the portal renders inside a [hidden] subtree */}
-      <TooltipPrimitive.Root data-slot='tooltip' {...props} open={isOpen} onOpenChange={setIsOpen} />
+      <PopoverPrimitive.Root data-slot='tooltip' {...props} open={isOpen} onOpenChange={setIsOpen} />
     </LocalTooltipProvider>
   );
 }
 
-type TooltipTriggerProps = ComponentProps<typeof TooltipPrimitive.Trigger> & { asChild?: boolean };
-function TooltipTrigger({ onMouseMove, onClick, asChild, children, ...props }: TooltipTriggerProps) {
-  const { isOpen, setOpen, x, y, followCursor, triggerRef } = useTooltip();
+type TooltipTriggerProps = ComponentProps<typeof PopoverPrimitive.Trigger> & { asChild?: boolean };
+function TooltipTrigger({ onMouseMove, asChild, children, openOnHover = true, delay, ...props }: TooltipTriggerProps) {
+  const providerDelay = use(TooltipDelayContext);
+  const { x, y, followCursor } = useTooltip();
   const handleMouseMove = (event: Parameters<NonNullable<TooltipTriggerProps['onMouseMove']>>[0]) => {
     onMouseMove?.(event);
     const target = event.currentTarget.getBoundingClientRect();
     if (followCursor === 'x' || followCursor === true) x.set((event.clientX - target.left - target.width / 2) / 2);
     if (followCursor === 'y' || followCursor === true) y.set((event.clientY - target.top - target.height / 2) / 2);
   };
-  // Base UI tooltips only open on hover/focus-visible, which never happens on
-  // touch — toggle on tap when the device cannot hover.
-  const handleClick = (event: Parameters<NonNullable<TooltipTriggerProps['onClick']>>[0]) => {
-    onClick?.(event);
-    triggerRef.current = event.currentTarget as HTMLElement;
-    if (globalThis.matchMedia?.('(hover: none)').matches) {
-      setOpen(!isOpen);
-    }
-  };
   if (asChild && isValidElement(children)) {
     return (
-      <TooltipPrimitive.Trigger
+      <PopoverPrimitive.Trigger
         data-slot='tooltip-trigger'
+        openOnHover={openOnHover}
+        delay={delay ?? providerDelay}
         onMouseMove={handleMouseMove}
-        onClick={handleClick}
         render={children}
         {...props}
       />
     );
   }
   return (
-    <TooltipPrimitive.Trigger
+    <PopoverPrimitive.Trigger
       data-slot='tooltip-trigger'
+      openOnHover={openOnHover}
+      delay={delay ?? providerDelay}
       onMouseMove={handleMouseMove}
-      onClick={handleClick}
       {...props}
     >
       {children}
-    </TooltipPrimitive.Trigger>
+    </PopoverPrimitive.Trigger>
   );
 }
 
-type TooltipPortalProps = Omit<ComponentProps<typeof TooltipPrimitive.Portal>, 'keepMounted'>;
+type TooltipPortalProps = Omit<ComponentProps<typeof PopoverPrimitive.Portal>, 'keepMounted'>;
 function TooltipPortal(props: TooltipPortalProps) {
   const { isOpen } = useTooltip();
   return (
     <AnimatePresence>
-      {isOpen && <TooltipPrimitive.Portal keepMounted data-slot='tooltip-portal' {...props} />}
+      {isOpen && <PopoverPrimitive.Portal keepMounted data-slot='tooltip-portal' {...props} />}
     </AnimatePresence>
   );
 }
 
-type TooltipPositionerProps = ComponentProps<typeof TooltipPrimitive.Positioner>;
+type TooltipPositionerProps = ComponentProps<typeof PopoverPrimitive.Positioner>;
 function TooltipPositioner(props: TooltipPositionerProps) {
-  return <TooltipPrimitive.Positioner data-slot='tooltip-positioner' {...props} />;
+  return <PopoverPrimitive.Positioner data-slot='tooltip-positioner' {...props} />;
 }
 
-type TooltipPopupProps = Omit<ComponentProps<typeof TooltipPrimitive.Popup>, 'render'> & HTMLMotionProps<'div'>;
+type TooltipPopupProps = Omit<ComponentProps<typeof PopoverPrimitive.Popup>, 'render'> & HTMLMotionProps<'div'>;
 function TooltipPopup({
   transition = { type: 'spring', stiffness: 300, damping: 25 },
   style,
@@ -148,7 +117,7 @@ function TooltipPopup({
   const translateX = useSpring(x, followCursorSpringOptions);
   const translateY = useSpring(y, followCursorSpringOptions);
   return (
-    <TooltipPrimitive.Popup
+    <PopoverPrimitive.Popup
       render={
         <m.div
           key='tooltip-popup'
@@ -169,9 +138,9 @@ function TooltipPopup({
   );
 }
 
-type TooltipArrowProps = ComponentProps<typeof TooltipPrimitive.Arrow>;
+type TooltipArrowProps = ComponentProps<typeof PopoverPrimitive.Arrow>;
 function TooltipArrow(props: TooltipArrowProps) {
-  return <TooltipPrimitive.Arrow data-slot='tooltip-arrow' {...props} />;
+  return <PopoverPrimitive.Arrow data-slot='tooltip-arrow' {...props} />;
 }
 
 export {

--- a/src/ui/modules/core/animate/primitives/base/Tooltip.tsx
+++ b/src/ui/modules/core/animate/primitives/base/Tooltip.tsx
@@ -12,15 +12,18 @@ import {
   useMotionValue,
   useSpring,
 } from 'motion/react';
-import { type ComponentProps, isValidElement, useMemo } from 'react';
+import { type ComponentProps, isValidElement, type RefObject, useCallback, useEffect, useMemo, useRef } from 'react';
 
 type TooltipContextType = {
   isOpen: boolean;
   setIsOpen: TooltipProps['onOpenChange'];
+  /** Programmatic open/close (tap-to-toggle, outside dismiss) without Base UI event details. */
+  setOpen: (open: boolean) => void;
   x: MotionValue<number>;
   y: MotionValue<number>;
   followCursor?: boolean | 'x' | 'y';
   followCursorSpringOptions?: SpringOptions;
+  triggerRef: RefObject<HTMLElement | null>;
 };
 const [LocalTooltipProvider, useTooltip] = getStrictContext<TooltipContextType>('TooltipContext');
 
@@ -40,43 +43,81 @@ function Tooltip({
 }: TooltipProps) {
   const [isOpen, setIsOpen] = useControlledState({
     value: props?.open,
-    defaultValue: props?.defaultOpen,
+    defaultValue: props?.defaultOpen ?? false,
     onChange: props?.onOpenChange,
   });
   const x = useMotionValue(0);
   const y = useMotionValue(0);
+  const triggerRef = useRef<HTMLElement | null>(null);
+
+  const setOpen = useCallback(
+    (open: boolean) => {
+      (setIsOpen as unknown as (open: boolean, eventDetails?: unknown) => void)?.(open, undefined);
+    },
+    [setIsOpen]
+  );
+
+  // Touch devices open the tooltip by tapping the trigger (see TooltipTrigger),
+  // and nothing hover-based ever closes it — dismiss on the next press outside.
+  useEffect(() => {
+    if (!isOpen) return;
+    const handlePointerDown = (event: PointerEvent) => {
+      if (triggerRef.current?.contains(event.target as Node)) return;
+      setOpen(false);
+    };
+    document.addEventListener('pointerdown', handlePointerDown, true);
+    return () => document.removeEventListener('pointerdown', handlePointerDown, true);
+  }, [isOpen, setOpen]);
+
   const tooltipContextValue = useMemo(
-    () => ({ isOpen, setIsOpen, x, y, followCursor, followCursorSpringOptions }),
-    [isOpen, setIsOpen, x, y, followCursor, followCursorSpringOptions]
+    () => ({ isOpen, setIsOpen, setOpen, x, y, followCursor, followCursorSpringOptions, triggerRef }),
+    [isOpen, setIsOpen, setOpen, x, y, followCursor, followCursorSpringOptions]
   );
   return (
     <LocalTooltipProvider value={tooltipContextValue}>
-      <TooltipPrimitive.Root data-slot='tooltip' {...props} onOpenChange={setIsOpen} />
+      {/* Controlled: the tap-to-open path (touch devices) must drive Base UI's
+          internal state too, or the portal renders inside a [hidden] subtree */}
+      <TooltipPrimitive.Root data-slot='tooltip' {...props} open={isOpen} onOpenChange={setIsOpen} />
     </LocalTooltipProvider>
   );
 }
 
 type TooltipTriggerProps = ComponentProps<typeof TooltipPrimitive.Trigger> & { asChild?: boolean };
-function TooltipTrigger({ onMouseMove, asChild, children, ...props }: TooltipTriggerProps) {
-  const { x, y, followCursor } = useTooltip();
+function TooltipTrigger({ onMouseMove, onClick, asChild, children, ...props }: TooltipTriggerProps) {
+  const { isOpen, setOpen, x, y, followCursor, triggerRef } = useTooltip();
   const handleMouseMove = (event: Parameters<NonNullable<TooltipTriggerProps['onMouseMove']>>[0]) => {
     onMouseMove?.(event);
     const target = event.currentTarget.getBoundingClientRect();
     if (followCursor === 'x' || followCursor === true) x.set((event.clientX - target.left - target.width / 2) / 2);
     if (followCursor === 'y' || followCursor === true) y.set((event.clientY - target.top - target.height / 2) / 2);
   };
+  // Base UI tooltips only open on hover/focus-visible, which never happens on
+  // touch — toggle on tap when the device cannot hover.
+  const handleClick = (event: Parameters<NonNullable<TooltipTriggerProps['onClick']>>[0]) => {
+    onClick?.(event);
+    triggerRef.current = event.currentTarget as HTMLElement;
+    if (globalThis.matchMedia?.('(hover: none)').matches) {
+      setOpen(!isOpen);
+    }
+  };
   if (asChild && isValidElement(children)) {
     return (
       <TooltipPrimitive.Trigger
         data-slot='tooltip-trigger'
         onMouseMove={handleMouseMove}
+        onClick={handleClick}
         render={children}
         {...props}
       />
     );
   }
   return (
-    <TooltipPrimitive.Trigger data-slot='tooltip-trigger' onMouseMove={handleMouseMove} {...props}>
+    <TooltipPrimitive.Trigger
+      data-slot='tooltip-trigger'
+      onMouseMove={handleMouseMove}
+      onClick={handleClick}
+      {...props}
+    >
       {children}
     </TooltipPrimitive.Trigger>
   );

--- a/src/ui/modules/shared/cookie-consent/CookieConsent.tsx
+++ b/src/ui/modules/shared/cookie-consent/CookieConsent.tsx
@@ -123,12 +123,12 @@ export const CookieConsent = () => {
         role='dialog'
         aria-labelledby='cookie-banner-title'
         aria-describedby='cookie-banner-description'
-        className='fixed bottom-4 left-4 z-[9999] max-w-2xl rounded-[14px] border-[3px] border-[var(--frame)] bg-card p-8 shadow-[var(--shadow-brutal-lg)]'
+        className='fixed bottom-4 inset-x-4 sm:right-auto z-9999 sm:max-w-2xl rounded-[14px] border-[3px] border-(--frame) bg-card p-5 sm:p-8 shadow-(--shadow-brutal-lg)'
       >
-        <h3 id='cookie-banner-title' className='text-xl font-semibold tracking-[-0.03em]'>
+        <h3 id='cookie-banner-title' className='text-lg sm:text-xl font-semibold tracking-[-0.03em]'>
           {t('title')}
         </h3>
-        <p id='cookie-banner-description' className='mt-2 text-sm text-muted-foreground'>
+        <p id='cookie-banner-description' className='mt-2 text-xs sm:text-sm text-muted-foreground'>
           {t('description')}
         </p>
         <div className='mt-4 flex flex-wrap gap-2'>


### PR DESCRIPTION
## Description

Two touch-device bugs on the planner roadmap, reported on mobile:

1. **Roadmap radial nav untappable on phones.** Root cause found via `elementFromPoint` diagnosis with the page untouched: the **cookie consent banner** (`fixed bottom-4 left-4 z-[9999] max-w-2xl p-8`, no right inset) spans the full width and ~55% of the height on a phone, silently swallowing taps on 3 of the 4 radial buttons (and anything else in the lower half) until consent is given. The banner is now constrained (`inset-x-4`, compact padding/text on small screens, ~36% height) — and after consent every radial button verified tappable. The `RadialNav`/`FeatureList` components themselves were healthy (an earlier iteration touched `FeatureList`; reverted).
2. **Tooltips never opened on tap.** Base UI tooltips open on hover/focus-visible only, neither of which fires on touch — and the library [disables tooltips on touch by design](https://base-ui.com/react/components/tooltip) ([mui/base-ui#3530](https://github.com/mui/base-ui/issues/3530) closed as not-planned), same stance as Radix ([radix-ui/primitives#955](https://github.com/radix-ui/primitives/issues/955)).

### Approach (researched before landing)

Surveyed the established workarounds: the shadcn community standard is the HybridTooltip/TouchProvider pattern ([shadcn-ui/ui#2402](https://github.com/shadcn-ui/ui/issues/2402)) — conditionally rendering a Popover tree on touch — which exists because **Radix** has no hover-capable popover. **Base UI does**: `Popover.Trigger` supports `openOnHover`/`delay`/`closeDelay`, and its docs prescribe exactly this for hover-info content that must be reachable on touch.

So instead of a hand-rolled `matchMedia` toggle + document listener (first iteration of this PR), the shared tooltip primitive (`animate/primitives/base/Tooltip.tsx`) now composes **Base UI Popover with `openOnHover`** under the same exported `Tooltip*` API and `data-slot`s — zero changes at any of the ~25 call sites. This buys, built-in: hover-open on desktop, tap-open on touch, outside-press **and Escape** dismissal, popup focus on touch-open (avoids the virtual keyboard), and correct trigger ARIA (`aria-expanded`/popup wiring — the "toggletip" semantics recommended over `role="tooltip"` for tap-revealed content, cf. [Inclusive Components](https://inclusive-components.design/tooltips-toggletips/)).

Known trade-offs (accepted): Base UI `Tooltip.Provider` group-delay/skip-delay across adjacent triggers is lost (the app effectively used per-tooltip delay 0 anyway), and desktop click now also toggles the popup (harmless for text-only content).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update

## Related Issue

N/A (reported directly)

## Changes Made

- `src/ui/modules/core/animate/primitives/base/Tooltip.tsx` — tooltip primitive now composes `@base-ui/react/popover` with `openOnHover` (delay threaded from `TooltipProvider` via context); same exported API and `data-slot`s.
- `src/ui/modules/shared/cookie-consent/CookieConsent.tsx` — banner constrained on mobile (`inset-x-4`, compact padding and text on small screens).
- `src/ui/modules/core/animate/primitives/base/Tooltip.test.tsx` — unit tests for the wiring: `openOnHover` enabled, provider delay threading, per-trigger override, popup gating.

## Testing

- [x] Existing unit tests pass (`pnpm test:ut`)
- [x] Added new tests for changes
- [x] Manually tested in browser
- [ ] Build passes (`pnpm build`)

Playwright touch emulation (iPhone 13) against dev: tooltip opens on tap and closes on Escape; with the compact banner dismissed, all four radial nav buttons verified reachable and selecting. Desktop run: tooltip opens on hover and closes on leave. Full suite: 1283 tests green, `tsc --noEmit` clean, Biome clean.

## Screenshots (if applicable)

N/A (interaction fix)

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format`)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

The pre-existing E2E failure on `api/markdown` Cache-Control (`public, max-age=3600`) also appears on PR #332 and on re-runs of previously-green commits — environmental drift in the preview workers, unrelated to this diff.

---

## GIF (mandatory)

<div align="center">

<!-- Add a funny or cute GIF here -->

_Thanks for contributing!_ ✨

</div>
