### PR TITLE
ci: cache playwright browsers

### DIFF
--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -81,8 +81,18 @@ jobs:
           cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps chromium
+      - name: Install Playwright OS dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
       - name: Run E2E tests
         run: pnpm test:e2e
         env:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? '50%' : undefined,
   reporter: 'html',
   use: {
     baseURL: process.env.BASE_URL ?? 'http://localhost:3000',


### PR DESCRIPTION
Applies the same Playwright CI setup as fbuireu/biancafiore@5268598d:

- Cache Playwright browsers (`~/.cache/ms-playwright`) keyed by `pnpm-lock.yaml`, so browsers are only downloaded when the lockfile changes.
- On cache hit, only OS dependencies are installed (`playwright install-deps`).
- `workers: '50%'` in CI instead of a single worker.